### PR TITLE
Add FAQ assistant cookbook using Nugen

### DIFF
--- a/guides/07_Embedding_Wikipedia_articles_for_search_with_Nugen/07_Embedding_Wikipedia_articles_for_search_with_Nugen.ipynb
+++ b/guides/07_Embedding_Wikipedia_articles_for_search_with_Nugen/07_Embedding_Wikipedia_articles_for_search_with_Nugen.ipynb
@@ -13,9 +13,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Key exists? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "print(\"Key exists?\", bool(os.getenv(\"NUGEN_API_KEY\")))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
-    "id": "eMYwmArPzWby"
+    "id": "eMYwmArPzWby",
+    "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
     "### **Generating Embeddings with Nugen API**\n",
@@ -42,11 +61,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: mwclient in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (0.11.0)\n",
+      "Requirement already satisfied: mwparserfromhell in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (0.7.2)\n",
+      "Requirement already satisfied: pandas in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (3.0.0)\n",
+      "Requirement already satisfied: tiktoken in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (0.12.0)\n",
+      "Requirement already satisfied: requests in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (2.32.5)\n",
+      "Requirement already satisfied: openai in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (2.16.0)\n",
+      "Requirement already satisfied: requests-oauthlib in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from mwclient) (2.0.0)\n",
+      "Requirement already satisfied: numpy>=1.26.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from pandas) (2.4.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from pandas) (2.9.0.post0)\n",
+      "Requirement already satisfied: regex>=2022.1.18 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from tiktoken) (2026.1.15)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from requests) (3.4.4)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from requests) (3.11)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from requests) (2.6.3)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from requests) (2026.1.4)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (4.12.1)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (1.9.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (0.28.1)\n",
+      "Requirement already satisfied: jiter<1,>=0.10.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (0.12.0)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (2.12.5)\n",
+      "Requirement already satisfied: sniffio in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (1.3.1)\n",
+      "Requirement already satisfied: tqdm>4 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (4.67.1)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.11 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from openai) (4.15.0)\n",
+      "Requirement already satisfied: httpcore==1.* in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
+      "Requirement already satisfied: h11>=0.16 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.41.5 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (2.41.5)\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
+      "Requirement already satisfied: oauthlib>=3.0.0 in /Users/abhinavgupta/nugen-assessment/nugen-cookbook/.venv/lib/python3.11/site-packages (from requests-oauthlib->mwclient) (3.3.1)\n"
+     ]
+    }
+   ],
    "source": [
-    "!pip install --quiet mwclient==0.11.0 mwparserfromhell==0.6.6 pandas==1.5.3 tiktoken==0.7.0 openai==1.34.0 requests"
+    "import sys\n",
+    "!{sys.executable} -m pip install -U mwclient mwparserfromhell pandas tiktoken requests openai"
    ]
   },
   {
@@ -62,11 +120,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "id": "kk-ug8DD1N7E"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All imports successful\n"
+     ]
+    }
+   ],
    "source": [
     "import mwclient\n",
     "import mwparserfromhell\n",
@@ -74,7 +140,9 @@
     "import re\n",
     "import random\n",
     "import requests\n",
-    "import tiktoken"
+    "import tiktoken\n",
+    "\n",
+    "print(\"All imports successful\")"
    ]
   },
   {
@@ -92,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -100,14 +168,30 @@
     "id": "AjFprmJc1YSV",
     "outputId": "777388ec-be79-4772-d6d1-2b22106eaa6a"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nugen API configured\n"
+     ]
+    }
+   ],
    "source": [
+    "import os\n",
+    "\n",
     "url_api_server = \"https://api.nugen.in/inference/embeddings\"\n",
-    "api_key = <enter your api key>\n",
+    "\n",
+    "api_key = os.getenv(\"NUGEN_API_KEY\")\n",
+    "if not api_key:\n",
+    "    raise ValueError(\"NUGEN_API_KEY not set. Please export it in your terminal.\")\n",
+    "\n",
     "headers = {\n",
     "    \"Authorization\": f\"Bearer {api_key}\",\n",
     "    \"Content-Type\": \"application/json\"\n",
-    "}"
+    "}\n",
+    "\n",
+    "print(\"Nugen API configured\")\n"
    ]
   },
   {
@@ -124,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -151,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -164,7 +248,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 35 article titles for processing.\n"
+      "Selected 34 article titles for processing.\n"
      ]
     }
    ],
@@ -224,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -285,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -362,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -375,7 +459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 1838 sections in 179 pages.\n"
+      "Found 1788 sections in 171 pages.\n"
      ]
     }
    ],
@@ -388,35 +472,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filtered out 89 sections, leaving 1749 sections.\n",
-      "['Speed skating at the 2022 Winter Olympics']\n",
-      "{{Short description|none}}\n",
-      "{{Use dmy dates|date=February 2018}}\n",
-      "{{Infobox Oly...\n",
+      "Filtered out 82 sections, leaving 1706 sections.\n",
+      "['Olympic Green']\n",
+      "{{Short description|Olympic Park in Chaoyang, Beijing, China}}\n",
+      "{{for|the fore...\n",
       "\n",
-      "['Speed skating at the 2022 Winter Olympics', '==Qualification==']\n",
-      "{{Main|Speed skating at the 2022 Winter Olympics – Qualification}}\n",
-      "A total qu...\n",
+      "['Olympic Green', '== Venues ==', '=== Beijing National Stadium ===']\n",
+      "[[File:Beijing national stadium.jpg|thumb|200px|right|Beijing National Stadiu...\n",
       "\n",
-      "['Speed skating at the 2022 Winter Olympics', '==Qualification==', '===Qualification times===']\n",
-      "The following qualification times were released on July 1, 2021, and were unc...\n",
+      "['Olympic Green', '== Venues ==', '=== Beijing National Aquatics Center ===']\n",
+      "[[File:国家游泳中心夜景.jpg|thumb|200px|right|Beijing National Aquatics Center]]\n",
       "\n",
-      "['Speed skating at the 2022 Winter Olympics', '==Competition schedule==']\n",
-      "The following was the competition schedule for all speed skating events. With...\n",
+      "The...\n",
       "\n",
-      "['Speed skating at the 2022 Winter Olympics', '==Medal summary==', '===Medal table===']\n",
-      "{{Medals table\n",
-      " | caption  = \n",
-      " | host  = CHN\n",
-      " | flag_template = flagIOC\n",
-      " | ev...\n",
+      "['Olympic Green', '== Venues ==', '=== Beijing National Indoor Stadium ===']\n",
+      "The [[Beijing National Indoor Stadium]] ({{lang|zh-hans|国家体育馆}}) or \"the Fan\"...\n",
+      "\n",
+      "['Olympic Green', '== Venues ==', '=== Beijing National Speed Skating Oval ===']\n",
+      "The [[Beijing National Speed Skating Oval]] is an arena that was built for th...\n",
       "\n"
      ]
     }
@@ -467,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -499,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,14 +650,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1749 Wikipedia sections split into 2052 strings.\n"
+      "1706 Wikipedia sections split into 2006 strings.\n"
      ]
     }
    ],
@@ -646,7 +726,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -659,7 +739,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1749 Wikipedia sections split into 2052 strings.\n",
+      "1706 Wikipedia sections split into 2006 strings.\n",
       "Processing batch 0 to 99\n",
       "Processing batch 100 to 199\n",
       "Processing batch 200 to 299\n",
@@ -732,7 +812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -756,6 +836,181 @@
     "df.to_csv(SAVE_PATH, index=False)\n",
     "print(f\"Embeddings saved to {SAVE_PATH}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows: 2006\n",
+      "Embedding dim: 768\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import ast\n",
+    "\n",
+    "# Load saved embeddings CSV\n",
+    "df = pd.read_csv(\"winter_olympics_2022.csv\")\n",
+    "\n",
+    "# Convert embedding column from string -> list[float]\n",
+    "df[\"embedding\"] = df[\"embedding\"].apply(ast.literal_eval)\n",
+    "\n",
+    "print(\"Rows:\", len(df))\n",
+    "print(\"Embedding dim:\", len(df[\"embedding\"].iloc[0]))\n",
+    "df.head(2)\n",
+    "\n",
+    "def cosine_similarity(a, b):\n",
+    "    a = np.array(a, dtype=np.float32)\n",
+    "    b = np.array(b, dtype=np.float32)\n",
+    "    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-10))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cosine_similarity(a, b):\n",
+    "    a = np.array(a, dtype=np.float32)\n",
+    "    b = np.array(b, dtype=np.float32)\n",
+    "    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-10))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Query embedding dim: 768\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "\n",
+    "NUGEN_API_KEY = os.getenv(\"NUGEN_API_KEY\")  # must be set\n",
+    "assert NUGEN_API_KEY, \"NUGEN_API_KEY missing\"\n",
+    "\n",
+    "# TODO: replace with the same URL and model used earlier in the notebook\n",
+    "EMBEDDING_URL = \"https://api.nugen.in/inference/embeddings\"\n",
+    "EMBEDDING_MODEL = \"nugen-flash-embed\"\n",
+    "\n",
+    "def nugen_embed(texts):\n",
+    "    headers = {\n",
+    "        \"Authorization\": f\"Bearer {NUGEN_API_KEY}\",\n",
+    "        \"Content-Type\": \"application/json\",\n",
+    "    }\n",
+    "    payload = {\"model\": EMBEDDING_MODEL, \"input\": texts}\n",
+    "    r = requests.post(EMBEDDING_URL, headers=headers, json=payload, timeout=120)\n",
+    "    r.raise_for_status()\n",
+    "    data = r.json()\n",
+    "    return [item[\"embedding\"] for item in data[\"data\"]]\n",
+    "\n",
+    "query = \"Who hosted the 2022 Winter Olympics and where were they held?\"\n",
+    "query_embedding = nugen_embed([query])[0]\n",
+    "print(\"Query embedding dim:\", len(query_embedding))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Result 1 | score=0.7954 ---\n",
+      "Bids for the 2022 Winter Olympics\n",
+      "\n",
+      "==Candidate cities overview==\n",
+      "\n",
+      "On 15 November 2013, the IOC announced the list of the six applicant cities. On 7 July 2014, the IOC announced that there were three remaining applicant cities that would move on to the candidate phase; these were Almaty, Beijing and Oslo.\n",
+      "\n",
+      "On 1 October 2014, Oslo withdrew its application after one of the country's governing political parties [[Conservative Party (Norway)|Høyre]] decided not to support the application. The remaining two candidate cities were therefore Almaty and Beijing.\n",
+      "\n",
+      "Both of the candidate cities suggested hosting the Games between February 4–20, 2022. The Paralympics will be held from March 4–13. While another city suggested hosting the Games between February 11–27, 2022. The Paralympics will be held fr\n",
+      "\n",
+      "--- Result 2 | score=0.7914 ---\n",
+      "Beijing bid for the 2022 Winter Olympics\n",
+      "\n",
+      "==Venues==\n",
+      "\n",
+      "{{main|Venues of the 2022 Winter Olympics and Paralympics}}\n",
+      "The [[Beijing]] Olympic Games Bidding Committee unveiled the gymnasium layout plan for the 2022 Winter Olympic Games on 20 February 2014: five ice events will be held at the Olympic center, the Capital Indoor Stadium and the [[Beijing]] Wukesong Sports Center. Competitions for luge, bobsleigh and alpine skiing will be held in Xiaohaituo Mountain area northwest of [[Beijing]], 90 kilometers away from downtown. All other skiing events will be held in [[Taizicheng]] Area in [[Chongli District]], [[Zhangjiakou]], 220 kilometers away from downtown of Beijing and 130 kilometers away from Xiaohaituo Mountain Area.\n",
+      "\n",
+      "--- Result 3 | score=0.7898 ---\n",
+      "Venues of the 2022 Winter Olympics and Paralympics\n",
+      "\n",
+      "{{short description|none}}\n",
+      "{{2022 Winter Olympics}}\n",
+      "{{2022 Winter Paralympics}}\n",
+      "\n",
+      "The [[Beijing]] Olympic Games Bidding Committee unveiled the venue layout plan for the [[2022 Winter Olympics]] on 20 February 2014; the plan was include the five ice events at the [[Olympic Green]], the [[Capital Indoor Stadium]] and the [[Wukesong Sports Center]], which were some of the main venues of the [[2008 Summer Olympics]]. Competitions for luge, bobsleigh and alpine skiing were held at the [[Xiaohaituo Mountain Area]], in a northwest of Beijing (in the [[:zh:西大庄窠|West Dazhuangke]] village,{{NoteTag|Originally simply '''Zhuangke'''. It is said that the village ''Dazhuangke'' was officially renamed ''Xidazhuangke''/''West Dazhuangke'' to avoid confusi\n",
+      "\n",
+      "--- Result 4 | score=0.7784 ---\n",
+      "128th IOC Session\n",
+      "\n",
+      "==2022 Winter Olympics host city election==\n",
+      "\n",
+      "{{main article|Bids for the 2022 Winter Olympics}}\n",
+      "The host city of the [[2022 Winter Olympics]] was elected during the 128th IOC Session. Bids for the games were due to the IOC in 2013. In 2014, the IOC decided that [[Almaty]] and [[Beijing]] (as Oslo withdrew its bid), would become candidate cities, a year before the host city was elected.\n",
+      "\n",
+      "--- Result 5 | score=0.7642 ---\n",
+      "Bids for the 2022 Winter Olympics\n",
+      "\n",
+      "{{short description|none}}\n",
+      "{{Infobox Olympic bid|2022|Winter|\n",
+      "| main = yes\n",
+      "|logo =         2022 Beijing Olympic bid logo.svg\n",
+      "|logo-size =    200px\n",
+      "|map =          \n",
+      "|caption =      \n",
+      "|winner =       Beijing\n",
+      "|votes1 =       44\n",
+      "|runner-up =    Almaty\n",
+      "|votes2 =       40\n",
+      "|Paralympics =  Yes\n",
+      "|1stBid =       14 November 2013\n",
+      "|2ndBid =       <!-- (OPTIONAL) Date of second bid (if one) -->\n",
+      "|shortlist =    7 July 2014\n",
+      "|decision =     July 31, 2015\n",
+      "|notes =        <!-- (OPTIONAL) Any other notes, placed at bottom of template -->\n",
+      "}}\n",
+      "A total of six bids were initially submitted for the [[2022 Winter Olympics]]. Four of the bids were subsequently withdrawn by 1 October 2014, citing either the high costs of hosting the Games or the lack of local support, leaving [[Almaty\n"
+     ]
+    }
+   ],
+   "source": [
+    "top_k = 5\n",
+    "df[\"score\"] = df[\"embedding\"].apply(lambda e: cosine_similarity(e, query_embedding))\n",
+    "top = df.sort_values(\"score\", ascending=False).head(top_k)\n",
+    "\n",
+    "for i, row in enumerate(top.itertuples(index=False), start=1):\n",
+    "    print(f\"\\n--- Result {i} | score={row.score:.4f} ---\")\n",
+    "    print(row.text[:800])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -763,9 +1018,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python (Nugen 3.11)",
    "language": "python",
-   "name": "python3"
+   "name": "nugen311"
   },
   "language_info": {
    "codemirror_mode": {
@@ -777,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/guides/11_FAQ_Assistant_with_Nugen/README.md
+++ b/guides/11_FAQ_Assistant_with_Nugen/README.md
@@ -1,0 +1,29 @@
+# Building a Simple FAQ Assistant with Nugen
+
+## Problem Statement
+
+Customer support teams often need quick, accurate answers to frequently asked questions.
+This cookbook demonstrates how to build a simple FAQ assistant using Nugen models.
+
+## Target Audience
+
+- Beginners
+- Developers exploring Nugen APIs
+
+## Prerequisites
+
+- Python 3.9+
+- Nugen API Key
+- Basic Python knowledge
+
+## Expected Outcome
+
+By the end of this guide, you will be able to:
+
+- Send a user query to a Nugen model
+- Generate a helpful response
+- Display the answer in a clean, readable format
+
+## Related Documentation
+
+- https://docs.nugen.in/api-reference

--- a/guides/11_FAQ_Assistant_with_Nugen/faq_assistant.ipynb
+++ b/guides/11_FAQ_Assistant_with_Nugen/faq_assistant.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c67fcae1",
+   "metadata": {},
+   "source": [
+    "# Simple FAQ Assistant with Nugen\n",
+    "\n",
+    "This notebook demonstrates how to build a basic FAQ assistant using the Nugen API.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9264e018",
+   "metadata": {},
+   "source": [
+    "# Simple FAQ Assistant with Nugen\n",
+    "\n",
+    "This notebook demonstrates how to build a basic FAQ assistant using the Nugen API.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "005c1bb4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API key loaded: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "API_KEY = os.getenv(\"NUGEN_API_KEY\")\n",
+    "BASE_URL = \"https://api.nugen.in\"\n",
+    "\n",
+    "print(\"API key loaded:\", bool(API_KEY))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "36042372",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask_faq(question):\n",
+    "    payload = {\n",
+    "        \"model\": \"nugen-flash-instruct\",\n",
+    "        \"prompt\": f\"You are a helpful FAQ assistant.\\nQuestion: {question}\\nAnswer:\",\n",
+    "        \"max_tokens\": 150,\n",
+    "        \"temperature\": 0.3,\n",
+    "        \"stream\": False\n",
+    "    }\n",
+    "\n",
+    "    headers = {\n",
+    "        \"Authorization\": f\"Bearer {API_KEY}\",\n",
+    "        \"Content-Type\": \"application/json\"\n",
+    "    }\n",
+    "\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/api/v3/inference/completions\",\n",
+    "        json=payload,\n",
+    "        headers=headers,\n",
+    "        timeout=60\n",
+    "    )\n",
+    "\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()[\"choices\"][0][\"text\"]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3670dfc2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Question: How can I reset my account password?\n",
+      "\n",
+      "Answer:\n",
+      "To reset your account password, you can follow these steps:\n",
+      "\n",
+      "1. Go to your account settings.\n",
+      "2. Click on \"Forgot Password\" or \"Reset Password\" depending on your account type.\n",
+      "3. Follow the prompts to set a new password.\n",
+      "4. Once you have set a new password, you can log in to your account and reset your password.\n",
+      "\n",
+      "Note: Make sure to use strong and unique passwords for your account to protect your account from unauthorized access.\n"
+     ]
+    }
+   ],
+   "source": [
+    "question = \"How can I reset my account password?\"\n",
+    "answer = ask_faq(question)\n",
+    "\n",
+    "print(\"Question:\", question)\n",
+    "print(\"\\nAnswer:\")\n",
+    "print(answer)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03f2add8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a beginner-friendly FAQ assistant cookbook demonstrating how to call the Nugen inference API.
Includes a runnable Jupyter notebook and README covering prerequisites, setup, and expected outcomes.