### PR TITLE
Add customer support chatbot cookbook

### DIFF
--- a/guides/11_Build_Customer_Support_Chatbot/README.md
+++ b/guides/11_Build_Customer_Support_Chatbot/README.md
@@ -1,0 +1,38 @@
+# Customer Support Chatbot with Nugen
+
+Build a simple support chatbot using Nugen's Agents API.
+
+## What we're building
+
+A chatbot for "TechStore Electronics" that handles:
+- Product questions
+- Order tracking  
+- Returns & refunds
+- Basic troubleshooting
+
+## Before you start
+
+1. Get your API key from [platform.nugen.in](https://platform.nugen.in)
+2. Have Python 3.8+ installed
+3. That's it!
+
+## Run the notebook
+
+```bash
+pip install requests
+jupyter notebook customer_support_chatbot.ipynb
+```
+
+## Common issues
+
+| Problem | Fix |
+|---------|-----|
+| 401 error | Check your API key |
+| No response | Use `llama-v3p3-70b-instruct` model |
+| Rate limited | Add `time.sleep(1)` between calls |
+
+## Links
+
+- [Nugen Docs](https://docs.nugen.in)
+- [API Reference](https://docs.nugen.in/api-reference)
+- [Get API Key](https://platform.nugen.in)

--- a/guides/11_Build_Customer_Support_Chatbot/customer_support_chatbot.ipynb
+++ b/guides/11_Build_Customer_Support_Chatbot/customer_support_chatbot.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6acd6bf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --quiet requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f919488",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd519ce9",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Get your API key from [platform.nugen.in](https://platform.nugen.in)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cec9a65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "API_KEY = \"<your-api-key-here>\"  # Replace with your key\n",
+    "BASE_URL = \"https://api.nugen.in/agents\"\n",
+    "\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {API_KEY}\",\n",
+    "    \"Content-Type\": \"application/json\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e554eccf",
+   "metadata": {},
+   "source": [
+    "## Create the Support Agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e54554b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_config = {\n",
+    "    \"agent_name\": \"TechStore Support\",\n",
+    "    \"agent_description\": \"Customer support for TechStore Electronics\",\n",
+    "    \"model\": \"llama-v3p3-70b-instruct\",\n",
+    "    \"temperature\": 0.3,\n",
+    "    \"instructions\": \"\"\"You are a friendly support agent for TechStore Electronics.\n",
+    "Help customers with product questions, orders, returns, and basic troubleshooting.\n",
+    "Be concise and helpful. Our policies: 30-day returns for unopened items, \n",
+    "14-day for opened items, free shipping over $50.\"\"\",\n",
+    "    \"demonstrations\": [\n",
+    "        {\n",
+    "            \"user_input\": \"What's your return policy?\",\n",
+    "            \"model_output\": \"We offer 30-day returns for unopened items and 14-day for opened items. Just bring your receipt!\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"user_input\": \"My laptop won't turn on\",\n",
+    "            \"model_output\": \"Try this: 1) Check it's plugged in, 2) Hold power button 15 seconds, 3) Remove battery if possible. Did any help?\"\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/create/\", json=agent_config, headers=headers)\n",
+    "agent = response.json()\n",
+    "AGENT_ID = agent['id']\n",
+    "print(f\"Agent created: {AGENT_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84b63979",
+   "metadata": {},
+   "source": [
+    "## Chat with the Bot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adec66fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chat(message):\n",
+    "    response = requests.post(\n",
+    "        f\"{BASE_URL}/{AGENT_ID}/run/\",\n",
+    "        json={\"message\": message},\n",
+    "        headers=headers\n",
+    "    )\n",
+    "    return response.json().get(\"response\", \"Error\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dd576c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test it out\n",
+    "questions = [\n",
+    "    \"Do you have iPhones in stock?\",\n",
+    "    \"What's your return policy?\",\n",
+    "    \"My Bluetooth headphones won't connect\"\n",
+    "]\n",
+    "\n",
+    "for q in questions:\n",
+    "    print(f\"Customer: {q}\")\n",
+    "    print(f\"Bot: {chat(q)}\\n\")\n",
+    "    time.sleep(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdbba176",
+   "metadata": {},
+   "source": [
+    "## Try Your Own Questions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6532b590",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(chat(\"Can I get a price match?\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4156f314",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(chat(\"Where is my order TS-12345?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed5dbf7b",
+   "metadata": {},
+   "source": [
+    "## Usage Stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a91530f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats = requests.get(f\"{BASE_URL}/usage/\", headers=headers).json()\n",
+    "print(json.dumps(stats, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc28bd56",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "644bbae9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to delete the agent\n",
+    "# requests.delete(f\"{BASE_URL}/{AGENT_ID}\", headers=headers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "846b8e61",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Resources:** [Docs](https://docs.nugen.in) | [API](https://docs.nugen.in/api-reference) | [Platform](https://platform.nugen.in)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
New cookbook demonstrating how to build a customer support chatbot using Nugen Agents API.

- Simple TechStore support bot example
- Uses llama-v3p3-70b-instruct model
- Handles product questions, orders, returns, troubleshooting