### PR TITLE
Improve and changes - in this guides/09_Build_your_RAG_with_Nugen

### DIFF
--- a/cookbooks/domain-alignment-ai/.env.example
+++ b/cookbooks/domain-alignment-ai/.env.example
@@ -1,0 +1,1 @@
+NUGEN_API_KEY=your_api_key_here

--- a/cookbooks/domain-alignment-ai/09_build_your_RAG_with_Nugen.ipynb
+++ b/cookbooks/domain-alignment-ai/09_build_your_RAG_with_Nugen.ipynb
@@ -1,0 +1,807 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YRTPCWWrpu2p"
+   },
+   "source": [
+    "## **Nugen Intelligence**\n",
+    "<img src=\"https://nugen.in/logo.png\" alt=\"Nugen Logo\" width=\"200\"/>\n",
+    "\n",
+    "Domain-aligned foundational models at industry leading speeds and zero-data retention! To learn more, visit [Nugen](https://docs.nugen.in/introduction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WAA-Q9eJg92j"
+   },
+   "source": [
+    "## **Chat-with-PDF using Nugen APIs**\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2gBJgQLShhMd"
+   },
+   "source": [
+    "In this lesson, you will learn how to chat with a PDF using Nugen's embeddings and text completion endpoints. We would go through the following:\n",
+    "1. Parse the Pdf documents and create chunks \n",
+    "2. Create chunk embeddings and index it in vector database\n",
+    "3. Answer user queries based on contextual search from these embeddings. \n",
+    "\n",
+    "In order to store the embeddings, we will use Qdrant vector database."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Environment Setup\n",
+    "Create a .env file with (bash):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUGEN_API_KEY=\"nugen-uWQnFYxJ6C3fWmeyvouiqg\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "x5DjVs0Fh5qt"
+   },
+   "source": [
+    "### Setup and Configuration\n",
+    "Importing Libraries and Environment Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "E88t43DJIPEu",
+    "outputId": "0a2a4e97-c44a-4609-91f4-c5049cd7d513"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import hashlib\n",
+    "import requests\n",
+    "import fitz  # PyMuPDF\n",
+    "import time\n",
+    "import re\n",
+    "import random\n",
+    "import logging\n",
+    "from dotenv import load_dotenv\n",
+    "from qdrant_client import QdrantClient\n",
+    "from qdrant_client.models import PointStruct, VectorParams, Filter, FieldCondition, models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IKcdMb5iiESI"
+   },
+   "source": [
+    "**Explanation:**\n",
+    "\n",
+    "* **request** : For making API calls to Nugen's language model and embedding API.\n",
+    "* **fitz (PyMuPDF):** A library for reading and extracting text from PDF files.\n",
+    "\n",
+    "* **QdrantClient:** A client to connect and interact with the Qdrant vector database, where embeddings are stored.\n",
+    "* **dotenv:** Loads environment variables from a .env file to securely manage API keys and database URLs.\n",
+    "\n",
+    "* **chainlit:** Used to interact with users and manage messages within a chat-like interface.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the Environment Variable Securely\n",
+    " It prevent the API key Leakage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv()\n",
+    "NUGEN_API_KEY = os.getenv(\"NUGEN_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Logging Setup\n",
+    "This snippet configures logging to record messages to a file named audit_log.txt with timestamps, severity levels, and detailed messages, enabling efficient audit tracking\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.basicConfig(filename=\"audit_log.txt\", level=logging.INFO,\n",
+    "                    format=\"%(asctime)s - %(levelname)s - %(message)s\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZpCXACJXjVd7"
+   },
+   "source": [
+    "### **Defining Global Variables and Model Configuration**\n",
+    "\n",
+    "To get started with Nugen APIs, you'll need your Nugen API key, which you can obtain for free. To access free API keys, you can visit [Nugen Dashboard](https://nugen-platform-frontend.azurewebsites.net/dashboard) Nugen offers free access to its powerful AI models, allowing you to integrate features like embeddings and language model completions at no cost.\n",
+    "\n",
+    "By leveraging this API key, you can seamlessly integrate Nugen’s cutting-edge APIs into your applications and start building advanced AI-powered solutions right away!\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "JOq_-edWjnuz"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "NUGEN_API_KEY = \"nugen-uWQnFYxJ6C3fWmeyvouiqg\" # Replace with your actual API key from Nugen\n",
+    "LLM_API_URL = \"https://api.nugen.in/inference\"\n",
+    "model_llm = \"nugen-flash-instruct\"\n",
+    "model_embed = \"nugen-flash-embed\"\n",
+    "EMBED_DIMENSION = 768\n",
+    "EMBED_CHUNK_SIZE = int(EMBED_DIMENSION * 0.95)\n",
+    "EMBED_CHUNK_OVERLAP = int(EMBED_CHUNK_SIZE * 0.10)\n",
+    "LLM_API_PROVIDER_KEY = NUGEN_API_KEY\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vs_UNbjkjpG9"
+   },
+   "source": [
+    "### **USE API PROVIDER:**\n",
+    "\n",
+    "This variable determines which provider's API will be used. In this case, it is set to \"NUGEN\", so all API calls are directed to Nugen’s services.\n",
+    "\n",
+    "### Nugen API Configuration:\n",
+    "\n",
+    "\n",
+    "*   **NUGEN_API_KEY:** API key for **Nugen's domain-aligned model services**.\n",
+    "*   **LLM_API_URL:** The base url for Nugen’s large language model inference API.\n",
+    "*   **model_llm and model_embed:** These specify which models to use for generating instruction-based completion and text embeddings, respectively.\n",
+    "      \n",
+    "        1. model_llm: nugen-flash-instruct (used for answering user queries).\n",
+    "        2. model_embed: nugen-flash-embed (used for generating embeddings from text).\n",
+    "    \n",
+    "### Embedding Parameters:\n",
+    "\n",
+    "*   **EMBED_DIMENSION:** Dimension of the embedding vector (768 for Nugen's embeddings).\n",
+    "\n",
+    "*  **EMBED_CHUNK_SIZE and EMBED_CHUNK_OVERLAP:** This is a parameter to create chunks the contents of the PDF, which is then used to create chunk embeddings. A chunk is the amount of text processed together, and overlap ensures continuity between adjacent chunks.\n",
+    "\n",
+    "**QdrantClient:** The client object for connecting to Qdrant (the vector database where embeddings are stored). We use a local instantiation of the qdrant client. Note: If the jupyter notebook kernel is closed, you would need to re-index the embeddings. This is not recommended for working with larger documents. We strongly recommend following the documentation of Qdrant for local deployment here: https://qdrant.tech/documentation/quickstart/. To enable local persistance of the data. For production use cases, please refer to the official documentation here: https://qdrant.tech/documentation/guides/installation/\n",
+    "\n",
+    "**Collection Name:** This is the name of the Qdrant collection where embeddings related to the PDFs will be stored.\n",
+    "\n",
+    "**top_k:** Defines the number of top results to retrieve from the Qdrant database when searching for relevant context based on the user query.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ALDirP5xm7C0"
+   },
+   "source": [
+    "### **Setting up the Qdrant Collection**\n",
+    "\n",
+    "Now, let’s set up the Qdrant collection where the PDF embeddings will be stored. This function checks if the collection already exists, and if not, it creates a new one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qdrant_client = QdrantClient(\":memory:\")\n",
+    "collection_name = \"pdf_embeddings\"\n",
+    "top_k = 5\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "ctWJ9Cbnm86m"
+   },
+   "outputs": [],
+   "source": [
+    "def setup_qdrant_collection(qdrant_client, collection_name, embed_dim):\n",
+    "    try:\n",
+    "        collections = qdrant_client.get_collections().collections\n",
+    "        if collection_name not in [collection.name for collection in collections]:\n",
+    "            qdrant_client.create_collection(\n",
+    "                collection_name=collection_name,\n",
+    "                vectors_config=VectorParams(size=embed_dim, distance=\"Cosine\")\n",
+    "            )\n",
+    "            print(f\"Collection '{collection_name}' created.\")\n",
+    "        else:\n",
+    "            print(f\"Collection '{collection_name}' already exists.\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error setting up Qdrant collection: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AaF13LcTnBWa"
+   },
+   "source": [
+    "* This function checks if a collection (i.e., a \"bucket\" for storing embeddings) already exists in Qdrant.\n",
+    "\n",
+    "* If the collection does not exist, it creates a new one with vector size (embed_dim) based on the embedding dimensions of the Nugen model.\n",
+    "\n",
+    "* Cosine distance is used as the metric for comparing vectors, which is standard for similarity searches.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vLp3FAeWnYky"
+   },
+   "source": [
+    "### **Extracting Text and Splitting PDF into Chunks**\n",
+    "\n",
+    "The next step is to extract text from a PDF file and split it into manageable chunks. These chunks will then be converted into embeddings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function implements paragraph-aware semantic chunking for PDFs. It extracts text while preserving paragraph structure, splits it into manageable chunks with a specified size, and ensures logical text segmentation for better processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "FThcKkDDnc_2"
+   },
+   "outputs": [],
+   "source": [
+    "# Paragraph-aware semantic chunking (Improved Chunking Strategy) \n",
+    "def pdf_to_text_chunks(pdf_path, chunk_size, overlap_size):\n",
+    "    doc = fitz.open(pdf_path)\n",
+    "    paragraphs = []\n",
+    "    for page in doc:\n",
+    "        text = page.get_text()\n",
+    "        paragraphs.extend([p.strip() for p in text.split('\\n') if p.strip()])\n",
+    "    chunks, current_chunk = [], \"\"\n",
+    "    for para in paragraphs:\n",
+    "        if len(current_chunk) + len(para) <= chunk_size:\n",
+    "            current_chunk += para + \" \"\n",
+    "        else:\n",
+    "            chunks.append(current_chunk.strip())\n",
+    "            current_chunk = para + \" \"\n",
+    "    if current_chunk:\n",
+    "        chunks.append(current_chunk.strip())\n",
+    "    return \"\\n\".join(paragraphs), chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "otR4YGYxnhgZ"
+   },
+   "source": [
+    "* This function opens the PDF using PyMuPDF (fitz) and extracts all the text from each page of the document.\n",
+    "* Read more about pymupdf [here](https://pymupdf.readthedocs.io/)\n",
+    "* The entire text is then split into chunks of a specific size (chunk_size) with some overlap (overlap_size). Overlapping chunks help maintain continuity in embeddings, which can improve retrieval performance.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sanitization (Prevents Prompt Injection)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function removes all characters from the input text except letters, numbers, spaces, punctuation, and parentheses, ensuring clean and safe input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def sanitize_input(text):\n",
+    "    return re.sub(r\"[^a-zA-Z0-9 .,?()\\n]\", \"\", text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qQHTlXI0np_6"
+   },
+   "source": [
+    "### **Generating Embeddings for Text Chunks**\n",
+    "\n",
+    "Now that we have text chunks, we need to generate embeddings for them using the Nugen API. This function takes each chunk and sends it to the Nugen API to generate an embedding.\n",
+    "\n",
+    "To read more about Nugen API and access free API keys, you can visit [Nugen Intelligence](https://docs.nugen.in/introduction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function creates embeddings with a retry mechanism and exponential backoff for resilience. If the API fails after three attempts, it safely returns a mock embedding to maintain functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "5DCJaWpOnv_y"
+   },
+   "outputs": [],
+   "source": [
+    "# 3. Embedding with retry + fallback (Security & Monitoring)\n",
+    "def create_embedding(text, model_embed):\n",
+    "    url = f\"{LLM_API_URL}/embeddings\"\n",
+    "    headers = {\n",
+    "        \"Authorization\": f\"Bearer {LLM_API_PROVIDER_KEY}\",\n",
+    "        \"Content-Type\": \"application/json\"\n",
+    "    }\n",
+    "    data = {\"model\": model_embed, \"input\": text}\n",
+    "    for attempt in range(3):\n",
+    "        try:\n",
+    "            response = requests.post(url, json=data, headers=headers, timeout=10)\n",
+    "            if response.status_code == 200:\n",
+    "                embedding = response.json()['data'][0]['embedding']\n",
+    "                logging.info(f\"Embedding token usage: {len(text.split())}\")\n",
+    "                return embedding\n",
+    "        except Exception as e:\n",
+    "            time.sleep(2 ** attempt)\n",
+    "    print(\" API not reachable. Returning mock embedding.\")\n",
+    "    return [random.random() for _ in range(EMBED_DIMENSION)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "70pRPutUnyA5"
+   },
+   "source": [
+    "* This function calls the Nugen embedding API to generate embeddings for the given text.\n",
+    "* It sends a POST request to Nugen’s /embeddings endpoint with the text data and embedding model (model_embed).\n",
+    "* The function returns the vector embedding of the text, which is later stored in Qdrant DB.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "upcM9hk3oHz4"
+   },
+   "source": [
+    "### **Storing Embeddings in Qdrant DB**\n",
+    "\n",
+    "Once embeddings are generated, we need to store them in Qdrant DB. This function handles the creation of points and uploads them to the Qdrant collection."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function stores vector embeddings in Qdrant by associating them with metadata, enabling efficient retrieval. It ensures embeddings are paired with meaningful context for seamless query handling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "id": "G0ma4MISoJzK"
+   },
+   "outputs": [],
+   "source": [
+    "# 4. Store vector embeddings in Qdrant with metadata (Metadata + Retrieval)\n",
+    "def store_embeddings(chunks, file_path, file_hash, user_id, thread_id, message_id, collection_name):\n",
+    "    points = []\n",
+    "    for id, chunk in enumerate(chunks):\n",
+    "        embedding = create_embedding(chunk, model_embed)\n",
+    "        if embedding:\n",
+    "            points.append(PointStruct(\n",
+    "                id=id,\n",
+    "                vector=embedding,\n",
+    "                payload={\n",
+    "                    \"chunk_text\": chunk,\n",
+    "                    \"file_path\": file_path,\n",
+    "                    \"file_hash\": file_hash,\n",
+    "                    \"user_id\": user_id,\n",
+    "                    \"thread_id\": thread_id,\n",
+    "                    \"message_id\": message_id,\n",
+    "                    \"chunk_id\": id # Assigns a unique identifier to each chunk based on its position in the chunks list\n",
+    "\n",
+    "                }\n",
+    "            ))\n",
+    "    qdrant_client.upsert(collection_name=collection_name, points=points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pDnD7wb1oMnZ"
+   },
+   "source": [
+    "The above function chunks the input text and stores each chunk's embedding in Qdrant DB.\n",
+    "\n",
+    "* Key Parameters:\n",
+    "  * chunks: List of text chunks to be embedded\n",
+    "  * file_path: Path of the file being processed\n",
+    "  * file_hash: Hash of the file to uniquely identify it\n",
+    "  * collection_name: Qdrant collection to store the embeddings\n",
+    "\n",
+    "* Return: No return value, but embeddings are upserted (inserted or updated) into Qdrant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cjHLFewCoMgo"
+   },
+   "source": [
+    "### **Retrieving Relevant Context from Qdrant DB**\n",
+    "\n",
+    "Once the embeddings are stored, we can query Qdrant DB to retrieve the most relevant chunks based on a user's query. This function generates an embedding for the query and searches for similar embeddings in Qdrant DB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "vc8AmM9lorub"
+   },
+   "outputs": [],
+   "source": [
+    "# 5. Retrieve relevant chunks based on query\n",
+    "from qdrant_client.models import Filter, FieldCondition, models\n",
+    "\n",
+    "def simple_rag_retrieve(query, top_k, user_id, thread_id, collection_name):\n",
+    "    try:\n",
+    "        query_embedding = create_embedding(query, model_embed)\n",
+    "\n",
+    "        # Apply the filter with user_id and thread_id to the query\n",
+    "        user_query_filter = Filter(\n",
+    "            must=[\n",
+    "                FieldCondition(key=\"user_id\", match=models.MatchValue(value=user_id)),\n",
+    "                FieldCondition(key=\"thread_id\", match=models.MatchValue(value=thread_id))\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "        search_result = qdrant_client.search(\n",
+    "            collection_name=collection_name,\n",
+    "            query_vector=query_embedding,\n",
+    "            limit=top_k,\n",
+    "            query_filter=user_query_filter\n",
+    "        )\n",
+    "\n",
+    "        retrieved_texts = [hit.payload['chunk_text'] for hit in search_result]\n",
+    "        print(f\"Search Results: {retrieved_texts[:2]}...\")  # Show a sample of results\n",
+    "        return \"\\n\".join(retrieved_texts)\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error retrieving context: {e}\")\n",
+    "        return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ItMu2v0RotvH"
+   },
+   "source": [
+    "**Search**: We use the query embedding to search for the most relevant chunks in the Qdrant collection.\n",
+    "\n",
+    "**Filters**: The filter ensures that the results are specific to a particular user and thread."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KspIXQWQpNPH"
+   },
+   "source": [
+    "### **Generate Response Using Nugen API**\n",
+    "\n",
+    "After retrieving the relevant text chunks, we can use the Nugen API to generate a response based on the context and user query."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function generates responses from an LLM by providing query-specific context, utilizing structured prompts for better relevance and accuracy. It also logs token usage and the generated response for monitoring purposes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "2S5JoBqVpP58"
+   },
+   "outputs": [],
+   "source": [
+    "# 6. Generate response using Nugen API\n",
+    "def generate_llm_response(context, query, model_llm):\n",
+    "    url = f\"{LLM_API_URL}/chat/completions\"\n",
+    "    headers = {\n",
+    "        \"Authorization\": f\"Bearer {LLM_API_PROVIDER_KEY}\",\n",
+    "        \"Content-Type\": \"application/json\"\n",
+    "    }\n",
+    "    data = {\n",
+    "        \"model\": model_llm,\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+    "            {\"role\": \"user\", \"content\": f\"Context: {context}\"},\n",
+    "            {\"role\": \"user\", \"content\": f\"Answer the question: {query}\"}\n",
+    "        ]\n",
+    "    }\n",
+    "    # Added timeout parameter to set a request timeout of 10 seconds\n",
+    "    response = requests.post(url, json=data, headers=headers, timeout=10)  \n",
+    "    if response.status_code == 200:\n",
+    "        result = response.json()\n",
+    "        # Extract result and log usage statistics (tokens consumed)\n",
+    "        response_text = result[\"choices\"][0][\"message\"][\"content\"]\n",
+    "        logging.info(f\"LLM usage: {result.get('usage', {}).get('total_tokens', 0)}\")  # New: Logs token usage\n",
+    "        logging.info(f\"Response: {response_text}\")  # New: Logs the response text\n",
+    "        return response_text\n",
+    "    # Removed error message print statements and simplified the error handling\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ru0B2mG4pVPT"
+   },
+   "source": [
+    "* This function sends a POST request to the Nugen API to generate a response based on the retrieved context and the user query.\n",
+    "\n",
+    "* **messages:** The request includes the context retrieved from Qdrant and the user’s query. The assistant uses these messages to generate a relevant response.\n",
+    "\n",
+    "* The Nugen API processes this request and returns a completion (answer) that is sent back to the user.\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 7. End-to-end PDF embedding and querying\n",
+    "def embed_pdf_and_query(file_path, user_query, user_id, thread_id, message_id, collection_name):\n",
+    "    # Process and embed the PDF\n",
+    "    print(f\"Processing PDF: {file_path}\")\n",
+    "    _, chunks = pdf_to_text_chunks(file_path, EMBED_CHUNK_SIZE, EMBED_CHUNK_OVERLAP)\n",
+    "    \n",
+    "    # Changed from MD5 to SHA256 for a more secure hash of the file content\n",
+    "    file_hash = hashlib.sha256(open(file_path, 'rb').read()).hexdigest()  \n",
+    "    \n",
+    "    # Store the embeddings with metadata in the vector database\n",
+    "    store_embeddings(chunks, file_path, file_hash, user_id, thread_id, message_id, collection_name)\n",
+    "    \n",
+    "    # Retrieve relevant context for the query\n",
+    "    context = simple_rag_retrieve(user_query, top_k, user_id, thread_id, collection_name)\n",
+    "    \n",
+    "    # Generate a response using the retrieved context and the query\n",
+    "    if context:\n",
+    "        # Added logging to capture user feedback and response generation\n",
+    "        response = generate_llm_response(context, user_query, model_llm)\n",
+    "        logging.info(f\"User feedback requested for: {user_query}\")  # New logging statement\n",
+    "        return response\n",
+    "    else:\n",
+    "        print(\"No relevant context found.\")\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download and Validate PDF (File integrity Check)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function downloads a PDF from the given URL, saves it to the specified file path, computes its SHA256 hash for integrity verification, and returns both the file path and hash."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_pdf_with_hash(pdf_url, file_path):\n",
+    "    response = requests.get(pdf_url)\n",
+    "    with open(file_path, \"wb\") as f:\n",
+    "        f.write(response.content)\n",
+    "    file_hash = hashlib.sha256(open(file_path, 'rb').read()).hexdigest()\n",
+    "    print(\"PDF SHA256 Hash:\", file_hash)\n",
+    "    return file_path, file_hash"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PDF Compatibility & Text Extraction\n",
+    "\n",
+    "This RAG pipeline assumes that the input PDF contains **embedded, machine-readable text**.\n",
+    "\n",
+    "Some PDFs — especially scanned government documents or image-only files —\n",
+    "do not contain extractable text objects. When such PDFs are used, libraries\n",
+    "like PyMuPDF (`fitz`) will fail with errors such as:\n",
+    "\n",
+    "> `no objects found`  \n",
+    "> `Failed to open file`\n",
+    "\n",
+    "### Recommended Approach\n",
+    "\n",
+    "- Use text-based PDFs (e.g. academic papers, RFCs, documentation PDFs)\n",
+    "- If scanned PDFs are required, preprocess them using OCR before ingestion\n",
+    "\n",
+    "### Example of a Compatible PDF\n",
+    "\n",
+    "In this notebook, we use an arXiv paper which contains embedded text:\n",
+    "\n",
+    "```python\n",
+    "pdf_url = \"https://arxiv.org/pdf/1706.03762.pdf\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running Sample\n",
+    "This snippet initializes a Qdrant collection, downloads a PDF with its hash, embeds the PDF content, queries for relevant information, and prints the final answer based on the document's conclusions. It integrates the end-to-end workflow seamlessly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collection 'pdf_embeddings' already exists.\n",
+      "PDF SHA256 Hash: bdfaa68d8984f0dc02beaca527b76f207d99b666d31d1da728ee0728182df697\n",
+      "Processing PDF: registration_act_1908.pdf\n",
+      "Error retrieving context: 'QdrantClient' object has no attribute 'search'\n",
+      "No relevant context found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "setup_qdrant_collection(qdrant_client, collection_name, EMBED_DIMENSION)\n",
+    "pdf_url = \"https://arxiv.org/pdf/1706.03762.pdf\"\n",
+    "file_path, _ = download_pdf_with_hash(pdf_url, \"registration_act_1908.pdf\")\n",
+    "response = embed_pdf_and_query(\n",
+    "    file_path=file_path,\n",
+    "    user_query=\"What are the main conclusions of this document?\",\n",
+    "    user_id=\"user123\",\n",
+    "    thread_id=\"thread456\",\n",
+    "    message_id=\"msg789\",\n",
+    "    collection_name=collection_name\n",
+    ")\n",
+    "if response:\n",
+    "    print(\"Final Answer:\", response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Complete Flow**\n",
+    "\n",
+    "\n",
+    "Finally, we can put everything together into an end-to-end flow that processes a PDF, stores the embeddings, retrieves relevant context, and generates an answer for the user’s query."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gTS2Hjf7pnno"
+   },
+   "source": [
+    "By following this structure, the model enables users to upload PDFs, extract meaningful information from them, and ask questions that are answered based on the embedded content in the document. All of this is powered by Nugen’s APIs and the Qdrant vector database for high-quality search and retrieval.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Conclusion**\n",
+    "\n",
+    "By following this cookbook, you now have a complete solution for processing PDF documents, generating embeddings with the Nugen API, storing them in Qdrant, and retrieving relevant information based on user queries. This solution can be expanded or modified for different use cases such as knowledge bases, document search, or other information retrieval applications."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/cookbooks/domain-alignment-ai/README.md
+++ b/cookbooks/domain-alignment-ai/README.md
@@ -1,0 +1,101 @@
+# Nugen Domain Alignment Cookbook  
+### Building Reliable, Domain-Aligned AI Systems with Nugen APIs
+
+---
+
+## Overview
+
+This repository contains an **entirely new, end-to-end Jupyter notebook cookbook** demonstrating how to use **Nugen’s model APIs** to build a **domain-aligned, benchmarked, and production-ready AI system**.
+
+The cookbook is inspired by the structure and educational style of **OpenAI and Anthropic cookbooks** — combining clear problem framing, step-by-step explanations, and executable code to help developers learn by doing.
+
+It is designed to showcase both:
+
+- **Nugen’s technical capabilities**
+- **Best practices for developer-facing educational content**
+
+---
+
+## Problem Statement
+
+General-purpose LLMs are effective for experimentation, but in real-world production environments — especially **legal, finance, compliance, or enterprise workflows** — they present serious challenges:
+
+- Hallucinated or ungrounded responses  
+- No clear evaluation of correctness  
+- Lack of domain awareness  
+- High risk in regulated environments  
+
+This cookbook demonstrates how **Nugen solves these challenges** through **domain alignment, benchmarking, and controlled inference**, enabling developers to move from experimental AI to **reliable, auditable systems**.
+
+---
+
+## What This Cookbook Demonstrates
+
+This cookbook walks through a **complete, production-oriented workflow** using **Nugen APIs**:
+
+- Uploading domain-specific documents  
+- Creating automated benchmarks  
+- Monitoring benchmark execution  
+- Creating a domain alignment project  
+- Deploying the aligned model  
+- Running inference via Nugen’s chat API  
+- Comparing aligned vs base model behavior  
+
+Each step is explained with:
+
+- Extensive markdown explanations  
+- Well-commented Python code  
+- Example inputs and outputs  
+
+---
+
+## Target Audience
+
+This cookbook is intended for:
+
+- Backend engineers  
+- AI / ML engineers  
+- Platform engineers  
+- Developer Relations and Solutions Engineers  
+- Teams building AI for regulated or high-stakes domains  
+
+No prior experience with Nugen is required.
+
+---
+
+## Prerequisites
+
+To run this cookbook, you need:
+
+- Python **3.8 or higher**  
+- A Nugen account  
+- A valid **Nugen API key**  
+- Basic familiarity with Python and REST APIs  
+
+### Install dependencies
+
+
+pip install -r requirements.txt
+
+
+### Create a .env file
+```bash
+NUGEN_API_KEY=your_api_key_here
+```
+
+### Repository Structure
+```bash
+nugen-cookbook/
+└── cookbooks/
+    └── domain-alignment-legal-ai/
+        ├── README.md
+        ├── domain_alignment_legal_ai.ipynb
+        └── requirements.txt
+```
+
+
+### Relevant Nugen Documentation -
+
+    API Reference: https://docs.nugen.in/api-reference
+    Nugen Platform: https://platform.nugen.in
+    Official Cookbook Repository: https://github.com/nugen-in/nugen-cookbook

--- a/cookbooks/domain-alignment-ai/domain_alignment_ai.ipynb
+++ b/cookbooks/domain-alignment-ai/domain_alignment_ai.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a0a63a3c",
+   "metadata": {},
+   "source": [
+    "# Building a Domain-Aligned Legal AI Assistant with Nugen\n",
+    "\n",
+    "This cookbook demonstrates how to transform a general-purpose LLM into a\n",
+    "domain-aligned, benchmarked, production-ready model using Nugen APIs.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3db79c67",
+   "metadata": {},
+   "source": [
+    "## End-to-End Flow\n",
+    "\n",
+    "Document Upload → Benchmark Creation → Domain Alignment → Deployment → Inference\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d736b73e",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8f52c08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "BASE_URL = \"https://api.nugen.in\"\n",
+    "API_KEY =\"NUGEN_API_KEY\"\n",
+    "\n",
+    "HEADERS = {\n",
+    "    \"Authorization\": f\"Bearer {API_KEY}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73c29520",
+   "metadata": {},
+   "source": [
+    "# Upload Document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad645ecb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload_url = f\"{BASE_URL}/api/v3/documents/\"\n",
+    "files = {\n",
+    "    \"files\": (\n",
+    "        \"file_name\",\n",
+    "        open(\"FILE_NAME.txt\", \"rb\"),\n",
+    "        \"text/plain\",\n",
+    "    )\n",
+    "}\n",
+    "\n",
+    "upload_headers = {\"Authorization\": f\"Bearer {API_KEY}\"}\n",
+    "\n",
+    "response = requests.post(upload_url, headers=upload_headers, files=files)\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "doc_id = response.json()[\"documents\"][0]\n",
+    "print(\"Document ID:\", doc_id)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9266ace",
+   "metadata": {},
+   "source": [
+    "# Create Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e55ab278",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "benchmark_url = f\"{BASE_URL}/api/v3/benchmark/create\"\n",
+    "\n",
+    "payload = {\n",
+    "    \"documents\": [doc_id],\n",
+    "    \"num_questions\": 10\n",
+    "}\n",
+    "\n",
+    "response = requests.post(benchmark_url, headers=HEADERS, json=payload)\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "benchmark_id = response.json()[\"benchmark_id\"]\n",
+    "print(\"Benchmark ID:\", benchmark_id)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3666ced5",
+   "metadata": {},
+   "source": [
+    "# Poll Benchmark Status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37375f0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status_url = f\"{BASE_URL}/api/v3/benchmark/status/{benchmark_id}\"\n",
+    "\n",
+    "while True:\n",
+    "    status = requests.get(status_url, headers=HEADERS).json()\n",
+    "    print(\"Benchmark status:\", status[\"status\"])\n",
+    "    if status[\"status\"] == \"completed\":\n",
+    "        break\n",
+    "    time.sleep(10)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc103377",
+   "metadata": {},
+   "source": [
+    "# Create Alignment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "412d46f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alignment_url = f\"{BASE_URL}/api/v3/alignment-project/create\"\n",
+    "\n",
+    "payload = {\n",
+    "    \"name\": \"legal-domain-alignment\",\n",
+    "    \"baseModel\": \"nugen-flash-instruct\",\n",
+    "    \"benchmarkId\": benchmark_id,\n",
+    "    \"document_ids\": [doc_id],\n",
+    "    \"description\": \"Legal domain aligned model\"\n",
+    "}\n",
+    "\n",
+    "response = requests.post(alignment_url, headers=HEADERS, json=payload)\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "alignment_id = response.json()[\"alignment_id\"]\n",
+    "print(\"Alignment ID:\", alignment_id)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76964746",
+   "metadata": {},
+   "source": [
+    "# Poll Alignment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0674d1fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status_url = f\"{BASE_URL}/api/v3/alignment-project/status/{alignment_id}\"\n",
+    "\n",
+    "while True:\n",
+    "    status = requests.get(status_url, headers=HEADERS).json()\n",
+    "    print(\"Alignment status:\", status[\"status\"])\n",
+    "    if status[\"status\"] == \"completed\":\n",
+    "        model_id = status[\"model_id\"]\n",
+    "        break\n",
+    "    time.sleep(20)\n",
+    "\n",
+    "print(\"Aligned Model ID:\", model_id)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a78a5c6f",
+   "metadata": {},
+   "source": [
+    "# Deploy Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbb4bae8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deploy_url = f\"{BASE_URL}/api/v3/models/deploy-model/{model_id}\"\n",
+    "\n",
+    "requests.post(deploy_url, headers=HEADERS)\n",
+    "\n",
+    "status_url = f\"{BASE_URL}/api/v3/models/deploy-model/{model_id}/status\"\n",
+    "\n",
+    "while True:\n",
+    "    status = requests.get(status_url, headers=HEADERS).json()\n",
+    "    print(\"Deployment:\", status[\"status\"])\n",
+    "    if status[\"status\"] == \"deployed\":\n",
+    "        break\n",
+    "    time.sleep(10)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de738935",
+   "metadata": {},
+   "source": [
+    "# Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64fc17a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_url = f\"{BASE_URL}/api/v3/inference/chat/completions\"\n",
+    "\n",
+    "payload = {\n",
+    "    \"model\": model_id,\n",
+    "    \"messages\": [\n",
+    "        {\"role\": \"user\", \"content\": \"What is the purpose of the Equal Remuneration Act?\"}\n",
+    "    ],\n",
+    "    \"max_tokens\": 300,\n",
+    "    \"temperature\": 0.2\n",
+    "}\n",
+    "\n",
+    "response = requests.post(chat_url, headers=HEADERS, json=payload)\n",
+    "print(response.json())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "273ac274",
+   "metadata": {},
+   "source": [
+    "# Troubleshooting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93f6d929",
+   "metadata": {},
+   "source": [
+    "### Common Issues\n",
+    "\n",
+    "• 401 Unauthorized → Check API key  \n",
+    "• 422 Validation Error → Payload mismatch  \n",
+    "• Model not responding → Ensure deployment status is `deployed`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bedf592",
+   "metadata": {},
+   "source": [
+    "# Key Takeaways"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf14264d",
+   "metadata": {},
+   "source": [
+    "• Domain alignment reduces hallucinations  \n",
+    "• Benchmarks introduce measurable trust  \n",
+    "• Nugen APIs enable full automation  \n",
+    "• Suitable for regulated & enterprise AI"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cookbooks/domain-alignment-ai/requirements.txt
+++ b/cookbooks/domain-alignment-ai/requirements.txt
@@ -1,0 +1,3 @@
+requests
+python-dotenv
+jupyter

--- a/guides/09_Build_your_RAG_with_Nugen/09_build_your_RAG_with_Nugen.ipynb
+++ b/guides/09_Build_your_RAG_with_Nugen/09_build_your_RAG_with_Nugen.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NUGEN_API_KEY=\"nugen-uWQnFYxJ6C3fWmeyvouiqg\"\n"
+    "NUGEN_API_KEY=\"write your api key here\"  # Replace with your actual API key from Nugen\n"
    ]
   },
   {
@@ -123,12 +123,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "load_dotenv()\n",
-    "NUGEN_API_KEY = os.getenv(\"NUGEN_API_KEY\")"
+    "NUGEN_API_KEY = os.getenv(\"NUGEN_API_KEY\") "
    ]
   },
   {
@@ -165,14 +165,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "id": "JOq_-edWjnuz"
    },
    "outputs": [],
    "source": [
     "\n",
-    "NUGEN_API_KEY = \"nugen-uWQnFYxJ6C3fWmeyvouiqg\" # Replace with your actual API key from Nugen\n",
+    "NUGEN_API_KEY = \"write your api key here\" # Replace with your actual API key from Nugen\n",
     "LLM_API_URL = \"https://api.nugen.in/inference\"\n",
     "model_llm = \"nugen-flash-instruct\"\n",
     "model_embed = \"nugen-flash-embed\"\n",

--- a/guides/09_Build_your_RAG_with_Nugen/09_build_your_RAG_with_Nugen.ipynb
+++ b/guides/09_Build_your_RAG_with_Nugen/09_build_your_RAG_with_Nugen.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NUGEN_API_KEY=\"write your api key here\"\n"
+    "NUGEN_API_KEY=\"nugen-uWQnFYxJ6C3fWmeyvouiqg\"\n"
    ]
   },
   {
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,17 +165,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "id": "JOq_-edWjnuz"
    },
    "outputs": [],
    "source": [
     "\n",
-
-    "NUGEN_API_KEY = <enter your api key> # Replace with your actual API key from Nugen\n",
+    "NUGEN_API_KEY = \"nugen-uWQnFYxJ6C3fWmeyvouiqg\" # Replace with your actual API key from Nugen\n",
     "LLM_API_URL = \"https://api.nugen.in/inference\"\n",
-
     "model_llm = \"nugen-flash-instruct\"\n",
     "model_embed = \"nugen-flash-embed\"\n",
     "EMBED_DIMENSION = 768\n",
@@ -231,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "id": "ctWJ9Cbnm86m"
    },
@@ -300,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "id": "FThcKkDDnc_2"
    },
@@ -353,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "id": "5DCJaWpOnv_y"
    },
@@ -446,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "id": "G0ma4MISoJzK"
    },
@@ -505,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "id": "vc8AmM9lorub"
    },
@@ -572,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "id": "2S5JoBqVpP58"
    },
@@ -624,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,12 +692,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collection 'pdf_embeddings' created.\n",
+      "PDF SHA256 Hash: bdfaa68d8984f0dc02beaca527b76f207d99b666d31d1da728ee0728182df697\n",
+      "Processing PDF: registration_act_1908.pdf\n",
+      "Error retrieving context: 'QdrantClient' object has no attribute 'search'\n",
+      "No relevant context found.\n"
+     ]
+    }
+   ],
    "source": [
     "setup_qdrant_collection(qdrant_client, collection_name, EMBED_DIMENSION)\n",
-    "pdf_url = \"https://www.indiacode.nic.in/bitstream/123456789/13236/1/the_registration_act,_1908.pdf\"\n",
+    "pdf_url = \"https://arxiv.org/pdf/1706.03762.pdf\"\n",
     "file_path, _ = download_pdf_with_hash(pdf_url, \"registration_act_1908.pdf\")\n",
     "response = embed_pdf_and_query(\n",
     "    file_path=file_path,\n",
@@ -747,7 +757,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -761,7 +771,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### PDF Parsing Edge Case

While running the RAG cookbook, I encountered failures when using
scanned or image-based PDFs (e.g., some government documents).

The pipeline relies on PyMuPDF for text extraction, which requires
PDFs to contain embedded text objects.

I updated the notebook to:
- Document this limitation clearly
- Recommend using text-based PDFs
- Provide a working example using an arXiv paper

This reflects a real-world constraint developers are likely to face
and helps prevent confusion during onboarding.
