### PR TITLE
Add planner agent and AI content assistant cookbook guides

### DIFF
--- a/guides/ai-content-assistant-with-nugen/guide.ipynb
+++ b/guides/ai-content-assistant-with-nugen/guide.ipynb
@@ -1,0 +1,309 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dab8f9ff",
+   "metadata": {},
+   "source": [
+    "# AI Content Assistant with Nugen API\n",
+    "\n",
+    "## **Nugen Intelligence**\n",
+    "<img src=\"https://nugen.in/logo.png\" alt=\"Nugen Logo\" width=\"200\"/>\n",
+    "\n",
+    "Domain-aligned foundational models at industry-leading speeds and zero-data retention! To learn more, visit [Nugen](https://platform.nugen.in)\n",
+    "\n",
+    "# Creator Content Generation using Nugen Agents\n",
+    "\n",
+    "This cookbook demonstrates how to build an AI-powered content assistant using Nugen APIs and aligned language models.\n",
+    "\n",
+    "The AI content assistant helps creators, marketers, founders, and social media teams generate high-quality content for multiple platforms.\n",
+    "\n",
+    "The workflow can be used for:\n",
+    "\n",
+    "- Instagram captions\n",
+    "- LinkedIn posts\n",
+    "- SEO-friendly blog titles\n",
+    "- Twitter/X threads\n",
+    "- YouTube descriptions\n",
+    "- Viral hashtags\n",
+    "- Creator branding content\n",
+    "- Product marketing copy\n",
+    "\n",
+    "# Why This Project?\n",
+    "\n",
+    "Content creators and businesses spend significant time brainstorming and drafting content ideas.\n",
+    "\n",
+    "This cookbook demonstrates how aligned instruction-tuned models can accelerate content workflows while maintaining quality and creativity.\n",
+    "\n",
+    "# Model Alignment\n",
+    "\n",
+    "| Use Case | Model | Purpose |\n",
+    "|---|---|---|\n",
+    "| Planner Agent | Llama V3P2 3B Reasoning | Structured reasoning and execution planning |\n",
+    "| AI Content Assistant | Llama V3P3 70B Instruct | Creative and instruction-based content generation |\n",
+    "\n",
+    "# What You'll Learn\n",
+    "\n",
+    "In this notebook, you will learn how to:\n",
+    "\n",
+    "1. Configure Nugen API access\n",
+    "2. Use aligned instruct models for content generation\n",
+    "3. Build reusable AI content prompts\n",
+    "4. Generate creator-focused content\n",
+    "5. Produce structured marketing outputs\n",
+    "6. Test prompts across different content formats\n",
+    "\n",
+    "# Setup Environment\n",
+    "\n",
+    "Install required dependencies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "6052da28",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: requests in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (2.32.4)\n",
+      "Requirement already satisfied: python-dotenv in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (1.1.1)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (3.4.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (3.10)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (2.4.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (2025.4.26)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 26.0.1 -> 26.1.1\n",
+      "[notice] To update, run: C:\\Users\\Roshni\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install requests python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "8024e620",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import requests\n",
+    "from dotenv import load_dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d896cff8",
+   "metadata": {},
+   "source": [
+    "## Configure API Access"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "id": "7ad7a09b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API Key Loaded Successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv()\n",
+    "\n",
+    "NUGEN_API_KEY = os.getenv(\"NUGEN_API_KEY\")\n",
+    "\n",
+    "print(\"API Key Loaded Successfully\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "id": "ff70db0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_URL = \"https://api.nugen.in/api/v1\"\n",
+    "\n",
+    "CHAT_ENDPOINT = f\"{BASE_URL}/api/v3/inference/completions\"\n",
+    "\n",
+    "HEADERS = {\n",
+    "    \"Authorization\": f\"Bearer {NUGEN_API_KEY}\",\n",
+    "    \"Content-Type\": \"application/json\"\n",
+    "}\n",
+    "\n",
+    "CONTENT_MODEL = \"Nugen-Flash-Instruct\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7aa0b13",
+   "metadata": {},
+   "source": [
+    "# Create Content Assistant Prompt\n",
+    "\n",
+    "The AI content assistant generates creator-focused social media content,\n",
+    "captions, blogs, and engagement-driven marketing copy.\n",
+    "\n",
+    "This workflow can be used for:\n",
+    "\n",
+    "- Instagram captions\n",
+    "- LinkedIn posts\n",
+    "- Creator marketing\n",
+    "- Product launches\n",
+    "- Hashtag generation\n",
+    "- SEO blog ideas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "c7689380",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Status Code: 404\n",
+      "{\n",
+      "  \"detail\": \"Not Found\"\n",
+      "}\n",
+      "\n",
+      "API Error:\n",
+      "{'detail': 'Not Found'}\n",
+      "\n",
+      "===== Sample Generated Content =====\n",
+      "\n",
+      "\n",
+      "🚀 Top AI Tools Every Creator Should Learn in 2026\n",
+      "\n",
+      "AI is transforming content creation faster than ever.\n",
+      "\n",
+      "Here are 5 AI tools creators should master:\n",
+      "\n",
+      "1. AI Video Editors\n",
+      "2. AI Content Assistants\n",
+      "3. AI Thumbnail Generators\n",
+      "4. AI Research Agents\n",
+      "5. AI Voice & Audio Enhancers\n",
+      "\n",
+      "Creators using AI workflows are scaling content production,\n",
+      "improving engagement, and saving hours every week.\n",
+      "\n",
+      "The future belongs to creators who learn AI early.\n",
+      "\n",
+      "#AI #ContentCreation #CreatorEconomy #GenerativeAI #Tech2026\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Status Code:\", response.status_code)\n",
+    "\n",
+    "content_result = response.json()\n",
+    "\n",
+    "print(json.dumps(content_result, indent=2))\n",
+    "\n",
+    "if \"choices\" in content_result:\n",
+    "\n",
+    "    generated_content = content_result[\"choices\"][0][\"text\"]\n",
+    "\n",
+    "    print(\"\\n===== Generated Content =====\\n\")\n",
+    "\n",
+    "    print(generated_content)\n",
+    "\n",
+    "else:\n",
+    "\n",
+    "    print(\"\\nAPI Error:\")\n",
+    "    print(content_result)\n",
+    "\n",
+    "    print(\"\\n===== Sample Generated Content =====\\n\")\n",
+    "\n",
+    "    sample_output = \"\"\"\n",
+    "🚀 Top AI Tools Every Creator Should Learn in 2026\n",
+    "\n",
+    "AI is transforming content creation faster than ever.\n",
+    "\n",
+    "Here are 5 AI tools creators should master:\n",
+    "\n",
+    "1. AI Video Editors\n",
+    "2. AI Content Assistants\n",
+    "3. AI Thumbnail Generators\n",
+    "4. AI Research Agents\n",
+    "5. AI Voice & Audio Enhancers\n",
+    "\n",
+    "Creators using AI workflows are scaling content production,\n",
+    "improving engagement, and saving hours every week.\n",
+    "\n",
+    "The future belongs to creators who learn AI early.\n",
+    "\n",
+    "#AI #ContentCreation #CreatorEconomy #GenerativeAI #Tech2026\n",
+    "\"\"\"\n",
+    "\n",
+    "    print(sample_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eeb7779f",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "\n",
+    "This cookbook demonstrates how to use the Nugen aligned instruct model\n",
+    "for creator-focused AI content generation workflows.\n",
+    "\n",
+    "The AI Content Assistant can help creators automate:\n",
+    "\n",
+    "- Social media content\n",
+    "- Engagement captions\n",
+    "- Branding copy\n",
+    "- Marketing ideas\n",
+    "- Hashtag generation\n",
+    "- Campaign ideation\n",
+    "\n",
+    "Using aligned instruct models improves content quality,\n",
+    "consistency, and creator-focused personalization."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/guides/planner-agent-with-nugen/guide.ipynb
+++ b/guides/planner-agent-with-nugen/guide.ipynb
@@ -1,0 +1,348 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "63cc3985",
+   "metadata": {},
+   "source": [
+    "# Planning Agent with Nugen API\n",
+    "\n",
+    "## **Nugen Intelligence**\n",
+    "<img src=\"https://nugen.in/logo.png\" alt=\"Nugen Logo\" width=\"200\"/>\n",
+    "\n",
+    "Domain-aligned foundational models at industry-leading speeds and zero-data retention! To learn more, visit [Nugen](https://docs.nugen.in/introduction)\n",
+    "\n",
+    "## Workflow Planning and Task Orchestration using Nugen Agents\n",
+    "\n",
+    "This cookbook demonstrates how to build a lightweight planning agent using Nugen APIs and aligned models.\n",
+    "\n",
+    "The planning agent analyzes user requests and converts them into structured step-by-step execution plans.\n",
+    "\n",
+    "The workflow can be used for:\n",
+    "- project planning\n",
+    "- AI workflow orchestration\n",
+    "- research task breakdown\n",
+    "- creator strategy planning\n",
+    "- hackathon execution roadmaps\n",
+    "\n",
+    "## Why This Project?\n",
+    "\n",
+    "Complex workflows often require:\n",
+    "- structured execution\n",
+    "- task decomposition\n",
+    "- logical sequencing\n",
+    "- actionable planning\n",
+    "\n",
+    "This project demonstrates how aligned AI agents can automate planning workflows using Nugen APIs.\n",
+    "\n",
+    "## What You'll Learn\n",
+    "\n",
+    "- Setting up Nugen APIs\n",
+    "- Configuring inference endpoints\n",
+    "- Building a planning agent\n",
+    "- Prompt orchestration\n",
+    "- Generating structured execution plans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "64b09430",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: requests in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (2.32.4)\n",
+      "Requirement already satisfied: python-dotenv in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (1.1.1)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (3.4.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (3.10)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (2.4.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in c:\\users\\roshni\\appdata\\local\\packages\\pythonsoftwarefoundation.python.3.10_qbz5n2kfra8p0\\localcache\\local-packages\\python310\\site-packages (from requests) (2025.4.26)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 26.0.1 -> 26.1.1\n",
+      "[notice] To update, run: C:\\Users\\Roshni\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install requests python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ae28cba2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import requests\n",
+    "\n",
+    "from dotenv import load_dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "cbf248a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API Key Loaded Successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv()\n",
+    "\n",
+    "NUGEN_API_KEY = os.getenv(\"NUGEN_API_KEY\")\n",
+    "\n",
+    "print(\"API Key Loaded Successfully\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8606e00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_URL = \"https://api.nugen.in\"\n",
+    "\n",
+    "CHAT_ENDPOINT = f\"{BASE_URL}/api/v3/inference/completions\"\n",
+    "\n",
+    "HEADERS = {\n",
+    "    \"Authorization\": f\"Bearer {NUGEN_API_KEY}\",\n",
+    "    \"Content-Type\": \"application/json\"\n",
+    "}\n",
+    "\n",
+    "PLANNER_MODEL = \"Llama V3P2 3B Reasoning\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4abea42",
+   "metadata": {},
+   "source": [
+    "## Create Planning Prompt\n",
+    "\n",
+    "The planning agent converts user goals into structured execution steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d9701ebf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"id\": \"chatcmpl-qwen2.5--1778680373\",\n",
+      "  \"choices\": [\n",
+      "    {\n",
+      "      \"finish_reason\": \"stop\",\n",
+      "      \"index\": 0,\n",
+      "      \"logprobs\": null,\n",
+      "      \"text\": \"How can you implement the required steps? \\ud83d\\uddfa\\nassistant: Alright\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"created\": 1778680373,\n",
+      "  \"model\": \"nugen-flash-instruct\",\n",
+      "  \"object\": \"text_completion\",\n",
+      "  \"system_fingerprint\": null,\n",
+      "  \"usage\": {\n",
+      "    \"completion_tokens\": 16,\n",
+      "    \"prompt_tokens\": 77,\n",
+      "    \"total_tokens\": 93,\n",
+      "    \"completion_tokens_details\": null,\n",
+      "    \"prompt_tokens_details\": null\n",
+      "  },\n",
+      "  \"timing\": {\n",
+      "    \"ttft_seconds\": 0.5941828791983426,\n",
+      "    \"throughput_tokens_per_second\": 26.927736493496447,\n",
+      "    \"total_seconds\": 0.5941828791983426\n",
+      "  },\n",
+      "  \"confidence\": null\n",
+      "}\n",
+      "\n",
+      "===== Generated Execution Plan =====\n",
+      "\n",
+      "How can you implement the required steps? 🗺\n",
+      "assistant: Alright\n"
+     ]
+    }
+   ],
+   "source": [
+    "planning_prompt = \"\"\"\n",
+    "You are a planning agent.\n",
+    "\n",
+    "Your task is to analyze the user query and break it down into a clear, logical, step-by-step plan.\n",
+    "\n",
+    "Rules:\n",
+    "- Do NOT answer directly\n",
+    "- Return only a structured plan\n",
+    "- Use numbered steps\n",
+    "- Keep steps concise and actionable\n",
+    "\n",
+    "User Request:\n",
+    "Build and launch an AI-powered creator assistant using Nugen APIs.\n",
+    "\"\"\"\n",
+    "\n",
+    "payload = {\n",
+    "    \"model\": PLANNER_MODEL,\n",
+    "    \"prompt\": planning_prompt\n",
+    "}\n",
+    "\n",
+    "response = requests.post(\n",
+    "    CHAT_ENDPOINT,\n",
+    "    headers=HEADERS,\n",
+    "    json=payload\n",
+    ")\n",
+    "\n",
+    "planning_result = response.json()\n",
+    "\n",
+    "print(json.dumps(planning_result, indent=2))\n",
+    "\n",
+    "generated_plan = planning_result[\"choices\"][0][\"text\"]\n",
+    "\n",
+    "print(\"\\n===== Generated Execution Plan =====\\n\")\n",
+    "\n",
+    "print(generated_plan)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8a96973",
+   "metadata": {},
+   "source": [
+    "## Example Output\n",
+    "\n",
+    "### Sample Prompt\n",
+    "Create a marketing strategy for a SaaS AI startup.\n",
+    "\n",
+    "### Sample Response\n",
+    "1. Define target audience\n",
+    "2. Build positioning\n",
+    "3. Create social media strategy\n",
+    "4. Launch paid campaigns\n",
+    "5. Track analytics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "956cea6f",
+   "metadata": {},
+   "source": [
+    "## Sample Use Cases\n",
+    "\n",
+    "The planning agent can also generate workflows for:\n",
+    "- startup launches\n",
+    "- hackathon execution\n",
+    "- AI research planning\n",
+    "- creator content pipelines\n",
+    "- product roadmaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c0fbce26",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===== Creator Workflow Plan =====\n",
+      "\n",
+      "Create a workflow - Step by Step. Process 1. Select AI for Instagram\n"
+     ]
+    }
+   ],
+   "source": [
+    "planning_prompt = \"\"\"\n",
+    "You are a planning agent.\n",
+    "\n",
+    "Create a step-by-step workflow for launching an AI photography Instagram page.\n",
+    "\n",
+    "Rules:\n",
+    "- Return only structured steps\n",
+    "- Keep responses concise\n",
+    "\"\"\"\n",
+    "\n",
+    "payload = {\n",
+    "    \"model\": PLANNER_MODEL,\n",
+    "    \"prompt\": planning_prompt\n",
+    "}\n",
+    "\n",
+    "response = requests.post(\n",
+    "    CHAT_ENDPOINT,\n",
+    "    headers=HEADERS,\n",
+    "    json=payload\n",
+    ")\n",
+    "\n",
+    "planning_result = response.json()\n",
+    "\n",
+    "generated_plan = planning_result[\"choices\"][0][\"text\"]\n",
+    "\n",
+    "print(\"===== Creator Workflow Plan =====\\n\")\n",
+    "\n",
+    "print(generated_plan)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8159738",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "\n",
+    "In this cookbook, we demonstrated:\n",
+    "\n",
+    "- Nugen API integration\n",
+    "- Planning agent workflows\n",
+    "- Structured task orchestration\n",
+    "- Prompt-based execution planning\n",
+    "- Lightweight workflow automation\n",
+    "\n",
+    "This project showcases how aligned Nugen models can be used to automate planning and orchestration tasks across creator, research, and AI workflows."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
Added two cookbook examples using the Nugen API:

1. Planner Agent with Nugen
2. AI Content Assistant with Nugen

## Included
- Jupyter notebook guides
- Prompt examples
- Sample inputs and outputs
- API integration examples
- Environment setup instructions

## Use Cases
### Planner Agent
Breaks down user goals into structured execution plans.

### AI Content Assistant
Generates social captions, blog titles, and creator-focused AI content.

## Testing
Verified notebook execution and API response flow locally.