### PR TITLE
Add guide: Align an LLM and Build RAG with Nugen API

### DIFF
--- a/guides/align_and_rag_with_nugen/guide.ipynb
+++ b/guides/align_and_rag_with_nugen/guide.ipynb
@@ -1,0 +1,617 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Align an LLM and Build RAG with Nugen API\n",
+    "\n",
+    "In this tutorial, we'll walk through two key capabilities of the Nugen platform:\n",
+    "\n",
+    "1. **Model Alignment** — Fine-tune a small LLM on a domain-specific document using the Nugen Alignment API\n",
+    "2. **RAG (Retrieval-Augmented Generation)** — Build a simple question-answering system that retrieves relevant context from the document and uses the aligned model to generate accurate answers\n",
+    "\n",
+    "**What we'll use:**\n",
+    "- A summary of the **Indian Factories Act, 1948** as our domain document\n",
+    "- **Qwen 2.5 0.5B** as the base model for alignment (small and fast)\n",
+    "- **Nomic Embed Text v1.5** for generating text embeddings\n",
+    "- Pure Python with NumPy — no heavy dependencies like vector databases\n",
+    "\n",
+    "By the end, you'll have a working pipeline that can answer questions about the Factories Act using your aligned model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "You'll need:\n",
+    "- A **Nugen API key** (get one free at [platform.nugen.in](https://platform.nugen.in))\n",
+    "- Python 3.8+ with `requests` and `numpy` installed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies (skip if already installed)\n",
+    "!pip install requests numpy python-dotenv --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Setup and Authentication\n",
+    "\n",
+    "Load your Nugen API key. We recommend storing it in a `.env` file rather than hardcoding it.\n",
+    "\n",
+    "Create a `.env` file in this directory:\n",
+    "```\n",
+    "NUGEN_API_KEY=your_api_key_here\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import time\n",
+    "import requests\n",
+    "import numpy as np\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "API_KEY = os.getenv(\"NUGEN_API_KEY\")\n",
+    "BASE_URL = \"https://api.nugen.in/api/v3\"\n",
+    "\n",
+    "HEADERS = {\n",
+    "    \"Authorization\": f\"Bearer {API_KEY}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "# Quick check — make sure the key works\n",
+    "r = requests.get(f\"{BASE_URL}/models/base\", headers=HEADERS)\n",
+    "if r.status_code == 200:\n",
+    "    models = r.json()[\"models\"]\n",
+    "    print(f\"Connected to Nugen API. {len(models)} models available.\")\n",
+    "else:\n",
+    "    print(f\"Error: {r.status_code} — check your API key\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see which models support alignment (fine-tuning):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show alignment-ready models\n",
+    "for m in models:\n",
+    "    if m[\"alignment_ready\"]:\n",
+    "        print(f\"  {m['id']:40s} — {m['description']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use **`qwen-v2p5-0p5b-instruct`** — a small 0.5B parameter model. It aligns quickly and is perfect for demonstrating the workflow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 2: Upload a Document\n",
+    "\n",
+    "The Nugen alignment API learns from documents you upload. We'll use a summary of the **Indian Factories Act, 1948** — a real piece of Indian labor law covering health, safety, welfare, and working hours in factories.\n",
+    "\n",
+    "Supported file types: `.txt`, `.json`, `.jsonl`, `.md`, `.xml`, `.csv`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload the document\n",
+    "doc_path = \"indian_factories_act_summary.txt\"\n",
+    "\n",
+    "upload_headers = {\"Authorization\": f\"Bearer {API_KEY}\"}\n",
+    "files = [(\"files\", (doc_path, open(doc_path, \"rb\"), \"text/plain\"))]\n",
+    "\n",
+    "r = requests.post(f\"{BASE_URL}/documents\", headers=upload_headers, files=files)\n",
+    "upload_id = r.json()[\"document_ids\"][0]\n",
+    "print(f\"Upload ID: {upload_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wait for the document to finish processing\n",
+    "while True:\n",
+    "    r = requests.get(f\"{BASE_URL}/documents/{upload_id}\", headers=HEADERS)\n",
+    "    status = r.json()[\"status\"]\n",
+    "    doc_id = r.json()[\"document_id\"]\n",
+    "    print(f\"Status: {status}\")\n",
+    "    if status == \"READY\":\n",
+    "        break\n",
+    "    time.sleep(3)\n",
+    "\n",
+    "print(f\"\\nDocument ready. Document ID: {doc_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 3: Align the Model\n",
+    "\n",
+    "Now we create an alignment project. This tells Nugen to fine-tune `qwen-v2p5-0p5b-instruct` on our document so it becomes a specialist in the Factories Act."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create alignment project\n",
+    "alignment_payload = {\n",
+    "    \"name\": \"factories-act-alignment\",\n",
+    "    \"base_model\": \"qwen-v2p5-0p5b-instruct\",\n",
+    "    \"document_ids\": [doc_id],\n",
+    "    \"description\": \"Align Qwen 0.5B on Indian Factories Act for domain-specific QA\",\n",
+    "}\n",
+    "\n",
+    "r = requests.post(\n",
+    "    f\"{BASE_URL}/alignment-project/create\",\n",
+    "    headers=HEADERS,\n",
+    "    json=alignment_payload,\n",
+    ")\n",
+    "\n",
+    "alignment_id = r.json()[\"alignment_id\"]\n",
+    "print(f\"Alignment started!\")\n",
+    "print(f\"Alignment ID: {alignment_id}\")\n",
+    "print(f\"Status: {r.json()['status']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Poll until alignment completes\n# This typically takes 5-15 minutes for a small model + small document\n\nprint(\"Waiting for alignment to complete...\")\nprint(\"(This may take 5-15 minutes)\\n\")\n\nwhile True:\n    r = requests.get(\n        f\"{BASE_URL}/alignment-project/status/{alignment_id}\",\n        headers=HEADERS,\n    )\n    result = r.json()\n    status = result[\"status\"]\n    elapsed = \"\"\n    if result.get(\"start_time\"):\n        elapsed = f\" (started: {result['start_time'][:19]})\"\n\n    print(f\"  Status: {status}{elapsed}\")\n\n    if status in (\"READY\", \"COMPLETED\", \"FAILED\", \"STOPPED\"):\n        break\n    time.sleep(30)\n\nprint(f\"\\nAlignment finished with status: {status}\")\nif result.get(\"data\"):\n    aligned_model_id_from_alignment = result[\"data\"].get(\"model_id\")\n    print(f\"Aligned model ID: {aligned_model_id_from_alignment}\")\n    print(f\"Details: {json.dumps(result['data'], indent=2)}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 4: Deploy the Aligned Model\n",
+    "\n",
+    "Once alignment is complete, we need to deploy the aligned model so we can use it for inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List aligned models to find ours\n",
+    "r = requests.get(f\"{BASE_URL}/models/aligned\", headers=HEADERS)\n",
+    "aligned_models = r.json()\n",
+    "\n",
+    "print(\"Your aligned models:\")\n",
+    "for m in aligned_models:\n",
+    "    print(f\"  ID: {m['id']}  |  Status: {m.get('status', 'N/A')}\")\n",
+    "\n",
+    "# Use the most recently aligned model\n",
+    "aligned_model_id = aligned_models[-1][\"id\"] if aligned_models else None\n",
+    "print(f\"\\nUsing aligned model: {aligned_model_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Deploy the aligned model\n",
+    "r = requests.post(\n",
+    "    f\"{BASE_URL}/models/deploy-model/{aligned_model_id}\",\n",
+    "    headers=HEADERS,\n",
+    ")\n",
+    "print(f\"Deploy request: {r.status_code}\")\n",
+    "print(r.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wait for deployment\n",
+    "print(\"Waiting for model deployment...\\n\")\n",
+    "\n",
+    "while True:\n",
+    "    r = requests.get(\n",
+    "        f\"{BASE_URL}/models/deploy-model/{aligned_model_id}/status\",\n",
+    "        headers=HEADERS,\n",
+    "    )\n",
+    "    result = r.json()\n",
+    "    print(f\"  Deployment status: {result['status']}\")\n",
+    "    if result[\"status\"] in (\"COMPLETED\", \"FAILED\"):\n",
+    "        break\n",
+    "    time.sleep(15)\n",
+    "\n",
+    "print(f\"\\nModel deployed: {aligned_model_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quick test — ask the aligned model a question directly\n",
+    "\n",
+    "Before building the full RAG pipeline, let's see how the aligned model responds on its own:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chat(model, question, context=None, max_tokens=300):\n",
+    "    \"\"\"Send a question to a Nugen model and return the answer.\"\"\"\n",
+    "    if context:\n",
+    "        prompt = (\n",
+    "            f\"Use the following context to answer the question.\\n\\n\"\n",
+    "            f\"Context:\\n{context}\\n\\n\"\n",
+    "            f\"Question: {question}\"\n",
+    "        )\n",
+    "    else:\n",
+    "        prompt = question\n",
+    "\n",
+    "    r = requests.post(\n",
+    "        f\"{BASE_URL}/inference/chat/completions\",\n",
+    "        headers=HEADERS,\n",
+    "        json={\n",
+    "            \"model\": model,\n",
+    "            \"messages\": [{\"role\": \"user\", \"content\": prompt}],\n",
+    "            \"max_tokens\": max_tokens,\n",
+    "            \"temperature\": 0.3,\n",
+    "        },\n",
+    "    )\n",
+    "    return r.json()[\"choices\"][0][\"message\"][\"content\"]\n",
+    "\n",
+    "\n",
+    "# Ask the aligned model without RAG context\n",
+    "answer = chat(aligned_model_id, \"What is the maximum weekly working hours under the Factories Act?\")\n",
+    "print(\"Aligned model (no context):\")\n",
+    "print(answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 5: Build a Simple RAG Pipeline\n",
+    "\n",
+    "Now let's build RAG on top of the aligned model. The idea is simple:\n",
+    "\n",
+    "1. **Chunk** the document into smaller pieces\n",
+    "2. **Embed** each chunk using Nugen's embedding model\n",
+    "3. When a user asks a question, **embed the question** and **find the most similar chunks**\n",
+    "4. Pass those chunks as **context** to the aligned model\n",
+    "\n",
+    "This gives the model precise, relevant information to work with — reducing hallucination.\n",
+    "\n",
+    "### 5.1 — Chunk the document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the document\n",
+    "with open(\"indian_factories_act_summary.txt\", \"r\") as f:\n",
+    "    full_text = f.read()\n",
+    "\n",
+    "\n",
+    "def chunk_text(text, chunk_size=500, overlap=50):\n",
+    "    \"\"\"Split text into overlapping chunks by character count.\"\"\"\n",
+    "    chunks = []\n",
+    "    paragraphs = text.split(\"\\n\\n\")\n",
+    "    current = \"\"\n",
+    "\n",
+    "    for para in paragraphs:\n",
+    "        if len(current) + len(para) > chunk_size and current:\n",
+    "            chunks.append(current.strip())\n",
+    "            # Keep the last `overlap` characters for continuity\n",
+    "            current = current[-overlap:] + \"\\n\\n\" + para\n",
+    "        else:\n",
+    "            current = current + \"\\n\\n\" + para if current else para\n",
+    "\n",
+    "    if current.strip():\n",
+    "        chunks.append(current.strip())\n",
+    "\n",
+    "    return chunks\n",
+    "\n",
+    "\n",
+    "chunks = chunk_text(full_text)\n",
+    "print(f\"Document split into {len(chunks)} chunks\\n\")\n",
+    "for i, chunk in enumerate(chunks):\n",
+    "    print(f\"Chunk {i+1} ({len(chunk)} chars): {chunk[:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 — Generate embeddings for each chunk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EMBED_MODEL = \"nomic-embed-text-v1.5\"\n",
+    "\n",
+    "\n",
+    "def get_embeddings(texts):\n",
+    "    \"\"\"Get embeddings for a list of texts using Nugen's embedding API.\"\"\"\n",
+    "    r = requests.post(\n",
+    "        f\"{BASE_URL}/inference/embeddings\",\n",
+    "        headers=HEADERS,\n",
+    "        json={\"model\": EMBED_MODEL, \"input\": texts},\n",
+    "    )\n",
+    "    data = r.json()\n",
+    "    return [item[\"embedding\"] for item in data[\"data\"]]\n",
+    "\n",
+    "\n",
+    "# Embed all chunks\n",
+    "chunk_embeddings = get_embeddings(chunks)\n",
+    "chunk_matrix = np.array(chunk_embeddings)\n",
+    "\n",
+    "print(f\"Embedded {len(chunks)} chunks\")\n",
+    "print(f\"Embedding dimensions: {chunk_matrix.shape[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.3 — Retrieval: find relevant chunks for a question"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_relevant_chunks(question, top_k=3):\n",
+    "    \"\"\"Embed the question and find the most similar document chunks.\"\"\"\n",
+    "    q_embedding = np.array(get_embeddings([question])[0])\n",
+    "\n",
+    "    # Cosine similarity between question and each chunk\n",
+    "    similarities = chunk_matrix @ q_embedding / (\n",
+    "        np.linalg.norm(chunk_matrix, axis=1) * np.linalg.norm(q_embedding)\n",
+    "    )\n",
+    "\n",
+    "    # Get top-k most similar chunks\n",
+    "    top_indices = np.argsort(similarities)[::-1][:top_k]\n",
+    "\n",
+    "    results = []\n",
+    "    for idx in top_indices:\n",
+    "        results.append({\n",
+    "            \"chunk\": chunks[idx],\n",
+    "            \"score\": float(similarities[idx]),\n",
+    "            \"index\": int(idx),\n",
+    "        })\n",
+    "\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test retrieval\n",
+    "test_question = \"What are the rules about child labor?\"\n",
+    "relevant = find_relevant_chunks(test_question, top_k=2)\n",
+    "\n",
+    "print(f\"Question: {test_question}\\n\")\n",
+    "for r in relevant:\n",
+    "    print(f\"Chunk {r['index']+1} (score: {r['score']:.3f}):\")\n",
+    "    print(f\"  {r['chunk'][:120]}...\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.4 — RAG: Retrieve + Generate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(question, top_k=2):\n",
+    "    \"\"\"Full RAG pipeline: retrieve relevant chunks, then generate an answer.\"\"\"\n",
+    "    # Step 1: Retrieve\n",
+    "    relevant = find_relevant_chunks(question, top_k=top_k)\n",
+    "    context = \"\\n\\n\".join([r[\"chunk\"] for r in relevant])\n",
+    "\n",
+    "    # Step 2: Generate using the aligned model\n",
+    "    answer = chat(aligned_model_id, question, context=context)\n",
+    "\n",
+    "    return {\n",
+    "        \"question\": question,\n",
+    "        \"answer\": answer,\n",
+    "        \"sources\": [f\"Chunk {r['index']+1} (score: {r['score']:.3f})\" for r in relevant],\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 6: Try It Out!\n",
+    "\n",
+    "Let's ask some questions about the Indian Factories Act:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "questions = [\n",
+    "    \"What is the maximum number of hours a worker can work per week?\",\n",
+    "    \"What facilities must a factory provide for women workers?\",\n",
+    "    \"What are the penalties for violating the Factories Act?\",\n",
+    "    \"At what age is child labor prohibited in factories?\",\n",
+    "    \"What safety measures are required for dangerous machinery?\",\n",
+    "]\n",
+    "\n",
+    "for q in questions:\n",
+    "    result = ask(q)\n",
+    "    print(f\"Q: {result['question']}\")\n",
+    "    print(f\"A: {result['answer']}\")\n",
+    "    print(f\"Sources: {', '.join(result['sources'])}\")\n",
+    "    print(\"-\" * 70)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 7: Compare — Aligned Model vs Base Model\n",
+    "\n",
+    "Let's see if the aligned model performs better than the base model with the same RAG context:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "BASE_MODEL = \"llama-v3p2-3b-reasoning\"\ntest_q = \"What welfare facilities must a factory with 300 workers provide?\"\n\n# Get the same context for both models\nrelevant = find_relevant_chunks(test_q, top_k=2)\ncontext = \"\\n\\n\".join([r[\"chunk\"] for r in relevant])\n\nprint(f\"Question: {test_q}\\n\")\nprint(\"=\" * 60)\n\n# Base model + RAG\nbase_answer = chat(BASE_MODEL, test_q, context=context)\nprint(f\"BASE MODEL ({BASE_MODEL}):\")\nprint(base_answer)\n\nprint(\"\\n\" + \"=\" * 60)\n\n# Aligned model + RAG\naligned_answer = chat(aligned_model_id, test_q, context=context)\nprint(f\"ALIGNED MODEL ({aligned_model_id}):\")\nprint(aligned_answer)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "In this tutorial, we covered the full workflow:\n",
+    "\n",
+    "| Step | What we did | Nugen API used |\n",
+    "|------|-------------|----------------|\n",
+    "| 1 | Uploaded a domain document | `POST /documents` |\n",
+    "| 2 | Aligned a small LLM on the document | `POST /alignment-project/create` |\n",
+    "| 3 | Deployed the aligned model | `POST /models/deploy-model/{id}` |\n",
+    "| 4 | Chunked the document for retrieval | — (local Python) |\n",
+    "| 5 | Generated embeddings for each chunk | `POST /inference/embeddings` |\n",
+    "| 6 | Built a RAG pipeline: retrieve + generate | `POST /inference/chat/completions` |\n",
+    "\n",
+    "**Key takeaways:**\n",
+    "- Alignment is a single API call — Nugen handles the training infrastructure\n",
+    "- Embeddings + cosine similarity give us a lightweight vector search (no database needed)\n",
+    "- RAG grounds the model's answers in actual document content, reducing hallucination\n",
+    "- The aligned model can answer domain questions more accurately than the base model\n",
+    "\n",
+    "### Next steps\n",
+    "- Try aligning on a **larger or more complex document** (legal contracts, medical literature, technical manuals)\n",
+    "- Use Nugen's **benchmark API** to evaluate model quality automatically\n",
+    "- Add Nugen's **reranker** (`POST /inference/reranker`) to improve retrieval precision\n",
+    "- Scale the vector store using Qdrant or FAISS for larger document collections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Cleanup\n",
+    "\n",
+    "Undeploy the model when you're done to free resources:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to undeploy the model\n",
+    "# r = requests.delete(\n",
+    "#     f\"{BASE_URL}/models/undeploy-model/{aligned_model_id}\",\n",
+    "#     headers=HEADERS,\n",
+    "# )\n",
+    "# print(f\"Undeploy: {r.status_code}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/guides/align_and_rag_with_nugen/guide.ipynb
+++ b/guides/align_and_rag_with_nugen/guide.ipynb
@@ -322,175 +322,69 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Step 5: Build a Simple RAG Pipeline\n",
-    "\n",
-    "Now let's build RAG on top of the aligned model. The idea is simple:\n",
-    "\n",
-    "1. **Chunk** the document into smaller pieces\n",
-    "2. **Embed** each chunk using Nugen's embedding model\n",
-    "3. When a user asks a question, **embed the question** and **find the most similar chunks**\n",
-    "4. Pass those chunks as **context** to the aligned model\n",
-    "\n",
-    "This gives the model precise, relevant information to work with — reducing hallucination.\n",
-    "\n",
-    "### 5.1 — Chunk the document"
-   ]
+   "source": "---\n\n## Step 5: Build a RAG Pipeline\n\nNow let's build RAG on top of the aligned model. The pipeline has these stages:\n\n1. **Chunk** the document into smaller pieces (we'll try 3 different methods)\n2. **Embed** each chunk using Nugen's embedding model\n3. **Enhance** the user's query for better retrieval\n4. **Retrieve** the most similar chunks via cosine similarity\n5. **Re-rank** the retrieved chunks using Nugen's reranker for precision\n6. Pass the top chunks as **context** to the aligned model\n\n### 5.1 — Chunking Methods\n\nDifferent chunking strategies affect retrieval quality. Let's implement three methods and compare them."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Read the document\n",
-    "with open(\"indian_factories_act_summary.txt\", \"r\") as f:\n",
-    "    full_text = f.read()\n",
-    "\n",
-    "\n",
-    "def chunk_text(text, chunk_size=500, overlap=50):\n",
-    "    \"\"\"Split text into overlapping chunks by character count.\"\"\"\n",
-    "    chunks = []\n",
-    "    paragraphs = text.split(\"\\n\\n\")\n",
-    "    current = \"\"\n",
-    "\n",
-    "    for para in paragraphs:\n",
-    "        if len(current) + len(para) > chunk_size and current:\n",
-    "            chunks.append(current.strip())\n",
-    "            # Keep the last `overlap` characters for continuity\n",
-    "            current = current[-overlap:] + \"\\n\\n\" + para\n",
-    "        else:\n",
-    "            current = current + \"\\n\\n\" + para if current else para\n",
-    "\n",
-    "    if current.strip():\n",
-    "        chunks.append(current.strip())\n",
-    "\n",
-    "    return chunks\n",
-    "\n",
-    "\n",
-    "chunks = chunk_text(full_text)\n",
-    "print(f\"Document split into {len(chunks)} chunks\\n\")\n",
-    "for i, chunk in enumerate(chunks):\n",
-    "    print(f\"Chunk {i+1} ({len(chunk)} chars): {chunk[:80]}...\")"
-   ]
+   "source": "# Read the document\nwith open(\"indian_factories_act_summary.txt\", \"r\") as f:\n    full_text = f.read()\n\n\n# --- Method 1: Paragraph-based chunking ---\n# Splits on double newlines. Each paragraph becomes a chunk.\n# Simple and preserves natural document structure.\n\ndef chunk_by_paragraph(text, min_length=50):\n    \"\"\"Split on paragraph boundaries, skip very short fragments.\"\"\"\n    paragraphs = text.split(\"\\n\\n\")\n    return [p.strip() for p in paragraphs if len(p.strip()) > min_length]\n\n\n# --- Method 2: Fixed-size chunking with overlap ---\n# Splits by character count with overlap for continuity.\n# Good for uniformly sized chunks regardless of document structure.\n\ndef chunk_fixed_size(text, chunk_size=500, overlap=50):\n    \"\"\"Split into fixed-size character windows with overlap.\"\"\"\n    chunks = []\n    paragraphs = text.split(\"\\n\\n\")\n    current = \"\"\n\n    for para in paragraphs:\n        if len(current) + len(para) > chunk_size and current:\n            chunks.append(current.strip())\n            current = current[-overlap:] + \"\\n\\n\" + para\n        else:\n            current = current + \"\\n\\n\" + para if current else para\n\n    if current.strip():\n        chunks.append(current.strip())\n\n    return chunks\n\n\n# --- Method 3: Sentence-based chunking ---\n# Groups sentences into chunks of N sentences.\n# Finer granularity — better for precise retrieval on specific facts.\n\ndef chunk_by_sentences(text, sentences_per_chunk=4, overlap_sentences=1):\n    \"\"\"Split into groups of N sentences with overlap.\"\"\"\n    import re\n    sentences = re.split(r'(?<=[.!?])\\s+', text.replace(\"\\n\", \" \"))\n    sentences = [s.strip() for s in sentences if len(s.strip()) > 10]\n\n    chunks = []\n    step = sentences_per_chunk - overlap_sentences\n    for i in range(0, len(sentences), step):\n        group = sentences[i : i + sentences_per_chunk]\n        if group:\n            chunks.append(\" \".join(group))\n\n    return chunks\n\n\n# Apply all three methods\nparagraph_chunks = chunk_by_paragraph(full_text)\nfixed_chunks = chunk_fixed_size(full_text, chunk_size=500, overlap=50)\nsentence_chunks = chunk_by_sentences(full_text, sentences_per_chunk=4, overlap_sentences=1)\n\nprint(f\"Method 1 — Paragraph-based:  {len(paragraph_chunks)} chunks\")\nprint(f\"Method 2 — Fixed-size (500):  {len(fixed_chunks)} chunks\")\nprint(f\"Method 3 — Sentence-based (4 per chunk):  {len(sentence_chunks)} chunks\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### 5.2 — Generate embeddings for each chunk"
-   ]
+   "source": "### 5.2 — Compare chunking methods\n\nLet's embed all three chunk sets and see which one retrieves the most relevant content for a sample question."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "EMBED_MODEL = \"nomic-embed-text-v1.5\"\n",
-    "\n",
-    "\n",
-    "def get_embeddings(texts):\n",
-    "    \"\"\"Get embeddings for a list of texts using Nugen's embedding API.\"\"\"\n",
-    "    r = requests.post(\n",
-    "        f\"{BASE_URL}/inference/embeddings\",\n",
-    "        headers=HEADERS,\n",
-    "        json={\"model\": EMBED_MODEL, \"input\": texts},\n",
-    "    )\n",
-    "    data = r.json()\n",
-    "    return [item[\"embedding\"] for item in data[\"data\"]]\n",
-    "\n",
-    "\n",
-    "# Embed all chunks\n",
-    "chunk_embeddings = get_embeddings(chunks)\n",
-    "chunk_matrix = np.array(chunk_embeddings)\n",
-    "\n",
-    "print(f\"Embedded {len(chunks)} chunks\")\n",
-    "print(f\"Embedding dimensions: {chunk_matrix.shape[1]}\")"
-   ]
+   "source": "EMBED_MODEL = \"nomic-embed-text-v1.5\"\n\n\ndef get_embeddings(texts):\n    \"\"\"Get embeddings for a list of texts using Nugen's embedding API.\"\"\"\n    r = requests.post(\n        f\"{BASE_URL}/inference/embeddings\",\n        headers=HEADERS,\n        json={\"model\": EMBED_MODEL, \"input\": texts},\n    )\n    return [item[\"embedding\"] for item in r.json()[\"data\"]]\n\n\ndef search_chunks(query, chunk_list, chunk_matrix, top_k=3):\n    \"\"\"Cosine similarity search across a chunk set.\"\"\"\n    q_emb = np.array(get_embeddings([query])[0])\n    sims = chunk_matrix @ q_emb / (\n        np.linalg.norm(chunk_matrix, axis=1) * np.linalg.norm(q_emb)\n    )\n    top_idx = np.argsort(sims)[::-1][:top_k]\n    return [\n        {\"chunk\": chunk_list[i], \"score\": float(sims[i]), \"index\": int(i)}\n        for i in top_idx\n    ]\n\n\n# Embed all three chunk sets\npara_matrix = np.array(get_embeddings(paragraph_chunks))\nfixed_matrix = np.array(get_embeddings(fixed_chunks))\nsent_matrix = np.array(get_embeddings(sentence_chunks))\n\nprint(f\"Paragraph embeddings:  {para_matrix.shape}\")\nprint(f\"Fixed-size embeddings: {fixed_matrix.shape}\")\nprint(f\"Sentence embeddings:   {sent_matrix.shape}\")"
+  },
+  {
+   "cell_type": "code",
+   "source": "# Compare retrieval across chunking methods\ncompare_q = \"What are the rules about child labor in factories?\"\n\nprint(f\"Query: {compare_q}\\n\")\nprint(\"=\" * 70)\n\nfor name, c_list, c_matrix in [\n    (\"Paragraph-based\", paragraph_chunks, para_matrix),\n    (\"Fixed-size (500 chars)\", fixed_chunks, fixed_matrix),\n    (\"Sentence-based (4 per chunk)\", sentence_chunks, sent_matrix),\n]:\n    results = search_chunks(compare_q, c_list, c_matrix, top_k=1)\n    best = results[0]\n    print(f\"\\n{name} — top match (score: {best['score']:.3f}):\")\n    print(f\"  {best['chunk'][:150]}...\")\n    print(\"-\" * 70)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "We'll use **paragraph-based chunking** for the rest of this tutorial — it preserves the document's natural structure and works well for legal text where each section covers a distinct topic.\n\nYou can swap in `fixed_chunks`/`fixed_matrix` or `sentence_chunks`/`sent_matrix` to experiment with the other methods.\n\n### 5.3 — Query Enhancement\n\nGeneric or vague questions can hurt retrieval. We can use an LLM to rewrite the user's question into a more specific, search-friendly version before embedding it.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "def enhance_query(question):\n    \"\"\"Use an LLM to rewrite a vague question into a more specific one.\"\"\"\n    r = requests.post(\n        f\"{BASE_URL}/inference/chat/completions\",\n        headers=HEADERS,\n        json={\n            \"model\": \"llama-v3p2-3b-reasoning\",\n            \"messages\": [\n                {\n                    \"role\": \"user\",\n                    \"content\": (\n                        \"Rewrite this question to be more specific and detailed \"\n                        \"for searching a legal document about Indian factory regulations. \"\n                        \"Return ONLY the improved question, nothing else.\\n\\n\"\n                        f\"Original question: {question}\"\n                    ),\n                }\n            ],\n            \"max_tokens\": 100,\n            \"temperature\": 0.3,\n        },\n    )\n    return r.json()[\"choices\"][0][\"message\"][\"content\"]\n\n\n# Test it\noriginal = \"What about kids working?\"\nenhanced = enhance_query(original)\nprint(f\"Original:  {original}\")\nprint(f\"Enhanced:  {enhanced}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "### 5.4 — Re-ranking\n\nAfter retrieving candidate chunks by cosine similarity, we use Nugen's **reranker** endpoint to re-score them. The reranker is more accurate than embedding similarity alone because it looks at the query and chunk together."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def rerank_chunks(query, chunks_with_scores, top_k=2):\n    \"\"\"Re-rank retrieved chunks using Nugen's reranker for better precision.\"\"\"\n    texts = [item[\"chunk\"] for item in chunks_with_scores]\n\n    r = requests.post(\n        f\"{BASE_URL}/inference/reranker\",\n        headers=HEADERS,\n        json={\n            \"model\": aligned_model_id,\n            \"query\": query,\n            \"texts\": texts,\n            \"top_k\": top_k,\n        },\n    )\n    reranked = r.json()[\"results\"]\n\n    return [\n        {\n            \"chunk\": texts[item[\"index\"]],\n            \"rerank_score\": item[\"relevance_score\"],\n            \"original_index\": chunks_with_scores[item[\"index\"]][\"index\"],\n        }\n        for item in reranked\n    ]\n\n\n# Test reranker\ntest_q = \"What are the rules about child labor?\"\ncandidates = search_chunks(test_q, paragraph_chunks, para_matrix, top_k=5)\nreranked = rerank_chunks(test_q, candidates, top_k=2)\n\nprint(f\"Query: {test_q}\\n\")\nfor r in reranked:\n    print(f\"Chunk {r['original_index']+1} (rerank score: {r['rerank_score']:.3f}):\")\n    print(f\"  {r['chunk'][:120]}...\\n\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### 5.3 — Retrieval: find relevant chunks for a question"
-   ]
+   "source": "### 5.5 — Full RAG Pipeline: Enhance + Retrieve + Rerank + Generate\n\nNow we wire everything together into a single `ask` function:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def find_relevant_chunks(question, top_k=3):\n",
-    "    \"\"\"Embed the question and find the most similar document chunks.\"\"\"\n",
-    "    q_embedding = np.array(get_embeddings([question])[0])\n",
-    "\n",
-    "    # Cosine similarity between question and each chunk\n",
-    "    similarities = chunk_matrix @ q_embedding / (\n",
-    "        np.linalg.norm(chunk_matrix, axis=1) * np.linalg.norm(q_embedding)\n",
-    "    )\n",
-    "\n",
-    "    # Get top-k most similar chunks\n",
-    "    top_indices = np.argsort(similarities)[::-1][:top_k]\n",
-    "\n",
-    "    results = []\n",
-    "    for idx in top_indices:\n",
-    "        results.append({\n",
-    "            \"chunk\": chunks[idx],\n",
-    "            \"score\": float(similarities[idx]),\n",
-    "            \"index\": int(idx),\n",
-    "        })\n",
-    "\n",
-    "    return results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Test retrieval\n",
-    "test_question = \"What are the rules about child labor?\"\n",
-    "relevant = find_relevant_chunks(test_question, top_k=2)\n",
-    "\n",
-    "print(f\"Question: {test_question}\\n\")\n",
-    "for r in relevant:\n",
-    "    print(f\"Chunk {r['index']+1} (score: {r['score']:.3f}):\")\n",
-    "    print(f\"  {r['chunk'][:120]}...\\n\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 5.4 — RAG: Retrieve + Generate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def ask(question, top_k=2):\n",
-    "    \"\"\"Full RAG pipeline: retrieve relevant chunks, then generate an answer.\"\"\"\n",
-    "    # Step 1: Retrieve\n",
-    "    relevant = find_relevant_chunks(question, top_k=top_k)\n",
-    "    context = \"\\n\\n\".join([r[\"chunk\"] for r in relevant])\n",
-    "\n",
-    "    # Step 2: Generate using the aligned model\n",
-    "    answer = chat(aligned_model_id, question, context=context)\n",
-    "\n",
-    "    return {\n",
-    "        \"question\": question,\n",
-    "        \"answer\": answer,\n",
-    "        \"sources\": [f\"Chunk {r['index']+1} (score: {r['score']:.3f})\" for r in relevant],\n",
-    "    }"
-   ]
+   "source": "def ask(question, top_k=2, use_enhancement=True, use_reranker=True):\n    \"\"\"Full RAG pipeline: enhance query -> retrieve -> rerank -> generate.\"\"\"\n    print(f\"Original question: {question}\")\n\n    # Step 1: Query enhancement\n    search_query = question\n    if use_enhancement:\n        search_query = enhance_query(question)\n        print(f\"Enhanced query:    {search_query}\")\n\n    # Step 2: Retrieve candidates via cosine similarity\n    candidates = search_chunks(search_query, paragraph_chunks, para_matrix, top_k=5)\n\n    # Step 3: Rerank for precision\n    if use_reranker:\n        top_results = rerank_chunks(search_query, candidates, top_k=top_k)\n        context = \"\\n\\n\".join([r[\"chunk\"] for r in top_results])\n        sources = [\n            f\"Chunk {r['original_index']+1} (rerank: {r['rerank_score']:.3f})\"\n            for r in top_results\n        ]\n    else:\n        top_results = candidates[:top_k]\n        context = \"\\n\\n\".join([r[\"chunk\"] for r in top_results])\n        sources = [\n            f\"Chunk {r['index']+1} (sim: {r['score']:.3f})\"\n            for r in top_results\n        ]\n\n    # Step 4: Generate answer using the aligned model\n    answer = chat(aligned_model_id, question, context=context)\n\n    return {\"question\": question, \"answer\": answer, \"sources\": sources}"
   },
   {
    "cell_type": "markdown",
@@ -541,39 +435,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "BASE_MODEL = \"llama-v3p2-3b-reasoning\"\ntest_q = \"What welfare facilities must a factory with 300 workers provide?\"\n\n# Get the same context for both models\nrelevant = find_relevant_chunks(test_q, top_k=2)\ncontext = \"\\n\\n\".join([r[\"chunk\"] for r in relevant])\n\nprint(f\"Question: {test_q}\\n\")\nprint(\"=\" * 60)\n\n# Base model + RAG\nbase_answer = chat(BASE_MODEL, test_q, context=context)\nprint(f\"BASE MODEL ({BASE_MODEL}):\")\nprint(base_answer)\n\nprint(\"\\n\" + \"=\" * 60)\n\n# Aligned model + RAG\naligned_answer = chat(aligned_model_id, test_q, context=context)\nprint(f\"ALIGNED MODEL ({aligned_model_id}):\")\nprint(aligned_answer)"
+   "source": "BASE_MODEL = \"llama-v3p2-3b-reasoning\"\ntest_q = \"What welfare facilities must a factory with 300 workers provide?\"\n\n# Get context using the full pipeline (enhance + retrieve + rerank)\nenhanced_q = enhance_query(test_q)\ncandidates = search_chunks(enhanced_q, paragraph_chunks, para_matrix, top_k=5)\nreranked = rerank_chunks(enhanced_q, candidates, top_k=2)\ncontext = \"\\n\\n\".join([r[\"chunk\"] for r in reranked])\n\nprint(f\"Question: {test_q}\")\nprint(f\"Enhanced: {enhanced_q}\\n\")\nprint(\"=\" * 60)\n\n# Base model + RAG\nbase_answer = chat(BASE_MODEL, test_q, context=context)\nprint(f\"BASE MODEL ({BASE_MODEL}):\")\nprint(base_answer)\n\nprint(\"\\n\" + \"=\" * 60)\n\n# Aligned model + RAG\naligned_answer = chat(aligned_model_id, test_q, context=context)\nprint(f\"ALIGNED MODEL ({aligned_model_id}):\")\nprint(aligned_answer)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Summary\n",
-    "\n",
-    "In this tutorial, we covered the full workflow:\n",
-    "\n",
-    "| Step | What we did | Nugen API used |\n",
-    "|------|-------------|----------------|\n",
-    "| 1 | Uploaded a domain document | `POST /documents` |\n",
-    "| 2 | Aligned a small LLM on the document | `POST /alignment-project/create` |\n",
-    "| 3 | Deployed the aligned model | `POST /models/deploy-model/{id}` |\n",
-    "| 4 | Chunked the document for retrieval | — (local Python) |\n",
-    "| 5 | Generated embeddings for each chunk | `POST /inference/embeddings` |\n",
-    "| 6 | Built a RAG pipeline: retrieve + generate | `POST /inference/chat/completions` |\n",
-    "\n",
-    "**Key takeaways:**\n",
-    "- Alignment is a single API call — Nugen handles the training infrastructure\n",
-    "- Embeddings + cosine similarity give us a lightweight vector search (no database needed)\n",
-    "- RAG grounds the model's answers in actual document content, reducing hallucination\n",
-    "- The aligned model can answer domain questions more accurately than the base model\n",
-    "\n",
-    "### Next steps\n",
-    "- Try aligning on a **larger or more complex document** (legal contracts, medical literature, technical manuals)\n",
-    "- Use Nugen's **benchmark API** to evaluate model quality automatically\n",
-    "- Add Nugen's **reranker** (`POST /inference/reranker`) to improve retrieval precision\n",
-    "- Scale the vector store using Qdrant or FAISS for larger document collections"
-   ]
+   "source": "---\n\n## Summary\n\nIn this tutorial, we covered the full workflow:\n\n| Step | What we did | Nugen API used |\n|------|-------------|----------------|\n| 1 | Uploaded a domain document | `POST /documents` |\n| 2 | Aligned a small LLM on the document | `POST /alignment-project/create` |\n| 3 | Deployed the aligned model | `POST /models/deploy-model/{id}` |\n| 4 | Chunked the document (3 methods compared) | — (local Python) |\n| 5 | Generated embeddings for each chunk set | `POST /inference/embeddings` |\n| 6 | Enhanced user queries for better retrieval | `POST /inference/chat/completions` |\n| 7 | Retrieved candidate chunks via cosine similarity | `POST /inference/embeddings` |\n| 8 | Re-ranked chunks for precision | `POST /inference/reranker` |\n| 9 | Generated answers with the aligned model | `POST /inference/chat/completions` |\n\n**Key takeaways:**\n- Alignment is a single API call — Nugen handles the training infrastructure\n- Embeddings + cosine similarity give us a lightweight vector search (no database needed)\n- **Multiple chunking methods** let you tune retrieval granularity for your document type\n- **Query enhancement** rewrites vague questions into specific ones, improving retrieval accuracy\n- **Re-ranking** with Nugen's reranker endpoint adds a precision layer on top of embedding similarity\n- RAG grounds the model's answers in actual document content, reducing hallucination\n- The aligned model can answer domain questions more accurately than the base model"
   },
   {
    "cell_type": "markdown",

--- a/guides/align_and_rag_with_nugen/indian_factories_act_summary.txt
+++ b/guides/align_and_rag_with_nugen/indian_factories_act_summary.txt
@@ -1,0 +1,24 @@
+Indian Factories Act, 1948 - Key Provisions
+
+The Factories Act, 1948 is a social legislation enacted to regulate working conditions in factories across India. It applies to every factory employing 10 or more workers where power is used, or 20 or more workers where power is not used.
+
+CHAPTER I: DEFINITIONS
+Section 2(m) defines a factory as any premises where manufacturing processes are carried on with 10 or more workers using power, or 20 or more workers without power. Section 2(k) defines manufacturing process as any process for making, altering, repairing, finishing, or adapting any article for use, sale, transport, or disposal.
+
+CHAPTER III: HEALTH PROVISIONS
+Section 11 mandates cleanliness in every factory. Floors, walls, and ceilings must be kept clean by regular washing, sweeping, and repainting. Section 12 requires effective arrangements for disposal of wastes and effluents. Section 13 mandates adequate ventilation and reasonable temperature. Section 14 requires prevention of dust and fume accumulation. Section 15 mandates artificial humidification only within prescribed limits. Section 16 requires prevention of overcrowding. Section 17 requires adequate lighting, natural or artificial. Section 18 mandates sufficient supply of wholesome drinking water. Section 19 requires separate latrines and urinals for male and female workers.
+
+CHAPTER IV: SAFETY PROVISIONS
+Section 21 requires fencing of dangerous machinery. Section 22 mandates that only trained adult male workers operate dangerous machines near moving parts. Section 23 prohibits employment of young persons on dangerous machines unless fully instructed on dangers and trained. Section 26 requires self-acting machines to have adequate clearance space. Section 27 prohibits women and children from cleaning or lubricating moving machinery. Section 36 mandates fire safety precautions and escape routes.
+
+CHAPTER V: WELFARE PROVISIONS
+Section 42 mandates washing facilities. Section 43 requires facilities for storing and drying clothing. Section 44 mandates sitting arrangements for workers who stand during work. Section 45 requires first-aid boxes (one per 150 workers). Section 46 mandates canteen facilities in factories with 250+ workers. Section 47 requires shelters, rest rooms, and lunch rooms in factories with 150+ workers. Section 48 mandates creche facilities in factories with 30+ women workers.
+
+CHAPTER VI: WORKING HOURS
+Section 51 limits weekly working hours to 48. Section 54 limits daily working hours to 9. Section 55 mandates rest intervals of at least 30 minutes after 5 hours of work. Section 56 prohibits spread-over beyond 10.5 hours. Section 59 mandates overtime wages at twice the ordinary rate. Section 52 mandates one weekly holiday. Section 79 entitles workers to annual leave with wages (one day per 20 days worked for adults, one day per 15 days for children).
+
+CHAPTER VII: EMPLOYMENT OF YOUNG PERSONS
+Section 67 prohibits employment of children below 14 years. Section 68 requires a certificate of fitness from a certifying surgeon for adolescents (15-18 years). Section 71 limits working hours for children to 4.5 hours per day. Section 72 prohibits night work for children (between 10 PM and 6 AM).
+
+PENALTIES AND ENFORCEMENT
+Section 92 prescribes penalties for contravention: imprisonment up to 2 years, or fine up to Rs. 1 lakh, or both. For continuing contravention, an additional fine of Rs. 1000 per day. Section 93 provides enhanced penalties for repeat offenders. Factory inspectors appointed under Section 8 have powers of entry, examination, and inquiry.


### PR DESCRIPTION
## New Guide: Align an LLM and Build RAG with Nugen API

A step-by-step tutorial covering the full Nugen alignment + RAG workflow:

1. Upload a domain document (Indian Factories Act, 1948)
2. Align Qwen 2.5 0.5B on the document using the Alignment API
3. Deploy the aligned model
4. Build a lightweight RAG pipeline (chunking + embeddings + cosine similarity)
5. Query the aligned model with retrieved context
6. Compare aligned vs base model performance

**Tech used:** Nugen Alignment API, Nugen Embeddings (nomic-embed-text-v1.5), Nugen Chat Completions, NumPy for vector search

**Files added:**
- `guides/align_and_rag_with_nugen/guide.ipynb`
- `guides/align_and_rag_with_nugen/indian_factories_act_summary.txt`